### PR TITLE
docs: add framework icons to LiveExamplesTabs

### DIFF
--- a/website/src/components/LiveExampleTabs/LiveExampleTabs.js
+++ b/website/src/components/LiveExampleTabs/LiveExampleTabs.js
@@ -24,6 +24,38 @@ const sandboxIcon = (
   </svg>
 )
 
+const chakraLogo = (
+  <svg
+    className={`${styles.icon} ${styles.chakra}`}
+    viewBox="0 0 582 582"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    focusable="false"
+    aria-hidden="true"
+  >
+    <rect className={styles.chakraCircle} width="582" height="582" rx="291" />
+    <path d="M157.521 303.421L355.881 106.426C359.587 102.746 365.55 107.225 363.049 111.809L289.22 247.123C287.573 250.141 289.758 253.821 293.196 253.821H420.782C424.892 253.821 426.877 258.857 423.872 261.661L200.293 470.326C196.284 474.067 190.317 468.796 193.536 464.356L299.373 318.351C301.543 315.357 299.404 311.164 295.706 311.164H160.713C156.67 311.164 154.653 306.27 157.521 303.421Z" />
+  </svg>
+)
+
+const muiLogo = (
+  <svg
+    className={styles.icon}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 36 32"
+    fill="none"
+    focusable="false"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M30.343 21.976a1 1 0 00.502-.864l.018-5.787a1 1 0 01.502-.864l3.137-1.802a1 1 0 011.498.867v10.521a1 1 0 01-.502.867l-11.839 6.8a1 1 0 01-.994.001l-9.291-5.314a1 1 0 01-.504-.868v-5.305c0-.006.007-.01.013-.007.005.003.012 0 .012-.007v-.006c0-.004.002-.008.006-.01l7.652-4.396c.007-.004.004-.015-.004-.015a.008.008 0 01-.008-.008l.015-5.201a1 1 0 00-1.5-.87l-5.687 3.277a1 1 0 01-.998 0L6.666 9.7a1 1 0 00-1.499.866v9.4a1 1 0 01-1.496.869l-3.166-1.81a1 1 0 01-.504-.87l.028-16.43A1 1 0 011.527.86l10.845 6.229a1 1 0 00.996 0L24.21.86a1 1 0 011.498.868v16.434a1 1 0 01-.501.867l-5.678 3.27a1 1 0 00.004 1.735l3.132 1.783a1 1 0 00.993-.002l6.685-3.839zM31 7.234a1 1 0 001.514.857l3-1.8A1 1 0 0036 5.434V1.766A1 1 0 0034.486.91l-3 1.8a1 1 0 00-.486.857v3.668z"
+      fill="#007FFF"
+    ></path>
+  </svg>
+)
+
 function getSandboxLink(id) {
   return `https://codesandbox.io/s/${id}?file=/src/App.tsx`
 }
@@ -43,12 +75,12 @@ const tabs = {
       label: 'View styled components 💅',
     },
     chakra: {
-      icon: sandboxIcon,
+      icon: chakraLogo,
       id: 'chakra',
       label: 'View Chakra',
     },
     joy: {
-      icon: sandboxIcon,
+      icon: muiLogo,
       id: 'joy',
       label: 'View MUI / Joy',
     },

--- a/website/src/components/LiveExampleTabs/LiveExampleTabs.module.css
+++ b/website/src/components/LiveExampleTabs/LiveExampleTabs.module.css
@@ -4,6 +4,14 @@
   justify-content: center;
 }
 
+.chakra path {
+  fill: var(--ps-neutral-surface) !important;
+}
+
+.chakraCircle {
+  fill: var(--ps-neutral-text-weak);
+}
+
 .codeIcon {
   padding-top: 4px;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Live examples tabs where using all default "codesandbox" icon.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Adds chakra & mui icons to tabs. SC uses an emoji which looks weird so we will probably keep it the codesandbox one.

## Other information
![Screen Shot 2022-03-22 at 5 09 28 PM](https://user-images.githubusercontent.com/4819738/159584781-ba281921-9ad9-4715-904b-b0795e703fd3.png)

