### PR TITLE
Docs/icons refine

### DIFF
--- a/website/docs/development/packages/icons/usage.mdx
+++ b/website/docs/development/packages/icons/usage.mdx
@@ -35,6 +35,8 @@ npm install @pluralsight/icons@alpha
 
 ## Basic example
 
+Icons are provided as simple inline SVG elements.
+
 <LiveExampleTabs
   fullCode={<BasicIconFullPreview />}
   sandboxList={{
@@ -50,7 +52,8 @@ npm install @pluralsight/icons@alpha
 :::tip
 
 This library provides only the svg element to allow for maximum flexibility.
-Additional attributes, such as sizing, will be provided by the `headless-styles` package.
+Additional attributes, such as sizing, will be provided by the `headless-styles`
+package, which can also be applied to custom icons.
 
 :::
 

--- a/website/docs/development/packages/icons/usage.mdx
+++ b/website/docs/development/packages/icons/usage.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-tags: [Development, Usage, Icons]
+tags: [Development, Usage, Icons, Web]
 ---
 
 import LiveExampleTabs from '@site/src/components/LiveExampleTabs/LiveExampleTabs'
@@ -17,7 +17,7 @@ import {
   IconColorFullPreview,
 } from '@site/src/components/Icons/IconColor.preview'
 
-# API
+# Usage (Web)
 
 :::caution
 

--- a/website/docs/development/packages/icons/usage.mdx
+++ b/website/docs/development/packages/icons/usage.mdx
@@ -54,26 +54,6 @@ Additional attributes, such as sizing, will be provided by the `headless-styles`
 
 :::
 
-### Importing by framework
-
-Icons can be imported by name from the package root for React JSX.
-
-```javascript
-import { menuIcon } from '@pluralsight/icons'
-```
-
-If you are using a different, supported framework, append its name to the path.
-
-```javascript
-import { menuIcon } from '@pluralsight/icons/svelte'
-```
-
-:::note
-
-If your bundler does not support tree shaking, please see our notes on [minimizing bundle size](#minimizing-bundle-size)
-
-:::
-
 ## Icon colors
 
 By default the icons are monochromatic and will inherit the `color` of their parent.
@@ -135,6 +115,26 @@ interface IconSizeGuide {
   }
 }
 ```
+
+## Importing by framework
+
+Icons can be imported by name from the package root for React JSX.
+
+```javascript
+import { menuIcon } from '@pluralsight/icons'
+```
+
+If you are using a different, supported framework, append its name to the path.
+
+```javascript
+import { menuIcon } from '@pluralsight/icons/svelte'
+```
+
+:::note
+
+If your bundler does not support tree shaking, please see our notes on [minimizing bundle size](#minimizing-bundle-size)
+
+:::
 
 ## Importing SVG files (fallback)
 

--- a/website/docs/development/packages/icons/usage_mobile.md
+++ b/website/docs/development/packages/icons/usage_mobile.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 3
+tags: [Development, Usage, Getting Started, Mobile, Icons]
+---
+
+# Usage (Mobile)
+
+:::caution
+
+This is **unreleased** documentation for Pluralsight Design **icons** package.
+
+:::
+
+:::note
+
+This is documentation for native mobile apps. If you are using React Native, please see our [web usage guide](./usage.md).
+
+:::

--- a/website/docs/development/packages/icons/usage_mobile.md
+++ b/website/docs/development/packages/icons/usage_mobile.md
@@ -13,6 +13,6 @@ This is **unreleased** documentation for Pluralsight Design **icons** package.
 
 :::note
 
-This is documentation for native mobile apps. If you are using React Native, please see our [web usage guide](./usage.md).
+This is documentation for native mobile apps. If you are using React Native, please see our [web usage guide](./usage.mdx).
 
 :::

--- a/website/src/components/Icons/BasicIcon.preview.js
+++ b/website/src/components/Icons/BasicIcon.preview.js
@@ -1,14 +1,16 @@
 import React from 'react'
 import CodeBlock from '@theme/CodeBlock'
 
-export function BasicIconPreview() {
+const preview = `export default function MenuIcon(props) {
   return (
-    <CodeBlock>{`const MenuIcon = (props) => (
-  <span {...getIconProps()} {...props}>
-    {menuIcon}
-  </span>
-)`}</CodeBlock>
+    <span {...getIconProps()} {...props}>
+      {menuIcon}
+    </span>
   )
+}`
+
+export function BasicIconPreview() {
+  return <CodeBlock>{preview}</CodeBlock>
 }
 
 export function BasicIconFullPreview() {
@@ -16,12 +18,6 @@ export function BasicIconFullPreview() {
     <CodeBlock>{`import { menuIcon } from '@pluralsight/icons'
 import { getIconProps } from '@pluralsight/headless-styles'
 
-const MenuIcon = (props) => (
-  <span {...getIconProps()} {...props}>
-    {menuIcon}
-  </span>
-)
-
-export default MenuIcon`}</CodeBlock>
+${preview}`}</CodeBlock>
   )
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- Single usage page titled "API"
- "Importing by framework" section nested below "Basic example"
- Example written using bound function ("fat arrow") syntax
- Basic example is just a code sample and a brief tip

## What is the new behavior?

- Renamed "API" to "Usage (Web)" and added a placeholder for mobile usage of the icons package
- "Importing by framework" toward the end of the document and no longer nested in another section for cleaner layout and most used sections towards the start
- Example uses standard function notation, since there was no reason for a bound function and it is easier to read
- Added a description to the basic example describing what is provided, and updated the tip to give more context around the separation of structure and attributes/styling

## Other information
