### PR TITLE
fix(hs): add correct height to base chakra class in Button

### DIFF
--- a/packages/headless-styles/src/components/Button/buttonCSS.module.css
+++ b/packages/headless-styles/src/components/Button/buttonCSS.module.css
@@ -127,7 +127,7 @@ html[data-theme='light'] .base.text:hover {
   border-radius: 6px !important;
   font-size: 1rem !important;
   font-weight: 600 !important;
-  height: 1.5rem !important;
+  height: 2.5rem !important;
   outline-offset: initial !important;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Chakra styles had incorrect size for "medium" in Button CSS
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates styles to use correct height.

## Other information
