### PR TITLE
docs: update gtag to use measurement ID vs. stream ID

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         gtag: {
-          trackingID: '3437648311',
+          trackingID: 'G-B4W12ZVHDB',
           anonymizeIP: true,
         },
         docs: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Analytics tracking but not actually sending "hits"
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Changed the ID to use the "measurement id" which is diff from docusaurus docs.

## Other information
