### PR TITLE
fix(hs): remove unnecessary padding prop in muiLabelOverride

### DIFF
--- a/packages/headless-styles/src/components/Badge/badgeJS.ts
+++ b/packages/headless-styles/src/components/Badge/badgeJS.ts
@@ -4,8 +4,6 @@ import styles from './generated/badgeCSS.module'
 import type { BadgeOptions } from './types'
 
 export const muiLabelOverride = `
-  padding: initial;
-
   .MuiChip-label {
     padding-left: initial;
     padding-right: initial;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
MUI - Badge extra padding declaration in `muiLabelOverride` was overriding our inline-padding props.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Removes it which allows the padding to be correct (tested in browser from sandbox).

## Other information
