### PR TITLE
fix(hs): temporarily remove type "module" in package.json

### DIFF
--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -2,7 +2,6 @@
   "name": "@pluralsight/headless-styles",
   "version": "0.0.0",
   "description": "Headless styles for Pluralsight.",
-  "type": "module",
   "main": "build/index.js",
   "module": "build/wrapper.mjs",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes to #200 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Imports are breaking apps that use older versions of Node (like our docs website) due to TS not fully supporting `.mjs` & `.cjs` extensions. Testing out if we can fix the error without doing too much surgery by just temporarily removing the `types` field until TS ships the [new feature](https://www.typescriptlang.org/docs/handbook/esm-node.html) which is [still buggy](https://github.com/microsoft/TypeScript/issues/46452)

## Other information
