### PR TITLE
feat(hs): add muiReset for Progress

### DIFF
--- a/packages/headless-styles/src/components/Progress/progressJS.ts
+++ b/packages/headless-styles/src/components/Progress/progressJS.ts
@@ -3,6 +3,15 @@ import { getA11yProgressProps, getDefaultProgressOptions } from './shared'
 import styles from './generated/progressCSS.module'
 import type { ProgressOptions } from './types'
 
+export const muiReset = {
+  bottom: 'initial',
+  display: 'block',
+  left: 'initial',
+  position: 'initial',
+  top: 'initial',
+  transformOrigin: 'initial',
+}
+
 export const ChakraProgress = {
   parts: ['filledTrack', 'track'],
   baseStyle: {

--- a/packages/headless-styles/src/index.ts
+++ b/packages/headless-styles/src/index.ts
@@ -11,7 +11,7 @@ export {
 } from './components/Button/buttonJS'
 
 export { getProgressProps } from './components/Progress/progressCSS'
-export { getJSProgressProps } from './components/Progress/progressJS'
+export { getJSProgressProps, muiReset } from './components/Progress/progressJS'
 
 export { getSkeletonProps } from './components/Skeleton/skeletonCSS'
 export { getJSSkeletonProps } from './components/Skeleton/skeletonJS'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #219 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Adds `muiReset` for the LinearProgress component (in MUI)

## Other information
**Reset vs. Override**

We are using the term "reset" here because we are literally resetting the styles on the MUI component itself. In the latter component (Badge) we are not resetting - we are overriding the styles of an internal element to the Badge.