### PR TITLE
fix:  use correct size property for Progress JS

### DIFF
--- a/packages/headless-styles/sandbox/src/components/Progress.jsx
+++ b/packages/headless-styles/sandbox/src/components/Progress.jsx
@@ -17,7 +17,7 @@ const { classes: insetStyles, ...insetA11y } = getProgressProps({
 
 export default function Progress(props) {
   if (props.logJS) {
-    console.log({ ...getJSProgressProps() })
+    console.log({ ...getJSProgressProps({ kind: 'inset' }) })
   }
 
   return (

--- a/packages/headless-styles/src/components/Progress/progressJS.ts
+++ b/packages/headless-styles/src/components/Progress/progressJS.ts
@@ -47,9 +47,10 @@ export type StyleKey = keyof typeof styles
 export function getJSProgressProps(options?: ProgressOptions) {
   const { kind, size, ...a11y } = getDefaultProgressOptions(options)
   const a11yProps = getA11yProgressProps(a11y)
+  const sizeKey = `${size}Size`
   const defaultStyles = {
     ...styles[kind as StyleKey],
-    ...styles[size as StyleKey],
+    ...styles[sizeKey as StyleKey],
   }
   const barStyles = {
     ...styles.bar,

--- a/packages/headless-styles/src/index.ts
+++ b/packages/headless-styles/src/index.ts
@@ -12,6 +12,7 @@ export {
 
 export { getProgressProps } from './components/Progress/progressCSS'
 export { getJSProgressProps, muiReset } from './components/Progress/progressJS'
+export type { ProgressOptions } from './components/Progress/types'
 
 export { getSkeletonProps } from './components/Skeleton/skeletonCSS'
 export { getJSSkeletonProps } from './components/Skeleton/skeletonJS'

--- a/packages/headless-styles/tests/progress/progressJS.test.ts
+++ b/packages/headless-styles/tests/progress/progressJS.test.ts
@@ -1,0 +1,21 @@
+import { getJSProgressProps } from '../../src'
+
+describe('progress JS', () => {
+  test('should return a distinct border-radius based on the kind', () => {
+    expect(getJSProgressProps().wrapper.styles.borderRadius).toEqual('20px')
+    expect(
+      getJSProgressProps({
+        kind: 'inset',
+      }).wrapper.styles.borderRadius
+    ).toEqual('initial')
+  })
+
+  test('should return a distinct height difference based on the size', () => {
+    expect(getJSProgressProps().wrapper.styles.height).toEqual('0.5rem')
+    expect(
+      getJSProgressProps({
+        size: 'xs',
+      }).wrapper.styles.height
+    ).toEqual('0.25rem')
+  })
+})


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #235 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
* Updates Progress JS API to use correct `size` property key
* Exposes ProgressOptions type for users (since they will have to build their own components)

## Other information
