### PR TITLE
fix(hs): add types.ts for non-TS environments

### DIFF
--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -6,8 +6,11 @@
   "module": "build/wrapper.js",
   "types": "build/index.d.ts",
   "exports": {
-    "import": "build/wrapper.js",
-    "require": "build/index.js"
+    ".": {
+      "import": "build/wrapper.js",
+      "require": "build/index.js"
+    },
+    "./types": "build/types"
   },
   "files": [
     "build/**/*"

--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -10,7 +10,10 @@
       "import": "build/wrapper.js",
       "require": "build/index.js"
     },
-    "./types": "build/types.d.ts"
+    "./types": {
+      "default": "build/types.d.ts",
+      "types": "build/types.d.ts"
+    }
   },
   "files": [
     "build/**/*"

--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -10,10 +10,7 @@
       "import": "build/wrapper.js",
       "require": "build/index.js"
     },
-    "./types": {
-      "default": "build/types.d.ts",
-      "types": "build/types.d.ts"
-    }
+    "./types": "build/types.d.ts"
   },
   "files": [
     "build/**/*"

--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -10,7 +10,7 @@
       "import": "build/wrapper.js",
       "require": "build/index.js"
     },
-    "./types": "build/types"
+    "./types": "build/types.d.ts"
   },
   "files": [
     "build/**/*"

--- a/packages/headless-styles/src/index.ts
+++ b/packages/headless-styles/src/index.ts
@@ -12,11 +12,9 @@ export {
 
 export { getCircularProgressProps } from './components/CircularProgress/circularProgressCSS'
 export { getJSCircularProgressProps } from './components/CircularProgress/circularProgressJS'
-export type { CircularProgressOptions } from './components/CircularProgress/types'
 
 export { getProgressProps } from './components/Progress/progressCSS'
 export { getJSProgressProps, muiReset } from './components/Progress/progressJS'
-export type { ProgressOptions } from './components/Progress/types'
 
 export { getSkeletonProps } from './components/Skeleton/skeletonCSS'
 export { getJSSkeletonProps } from './components/Skeleton/skeletonJS'

--- a/packages/headless-styles/src/types.ts
+++ b/packages/headless-styles/src/types.ts
@@ -1,0 +1,2 @@
+export type { CircularProgressOptions } from './components/CircularProgress/types'
+export type { ProgressOptions } from './components/Progress/types'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Non-TS loaders are failing due to us exporting types in the main entry
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Moves types exports to types.ts to prevent failures for non-TS environments

## Other information
