### PR TITLE
fix(headless-styles): rename icon size classes

### DIFF
--- a/packages/headless-styles/src/components/Icon/iconCSS.module.css
+++ b/packages/headless-styles/src/components/Icon/iconCSS.module.css
@@ -2,29 +2,29 @@
   display: inline-block;
 }
 
-.xsSize,
-.sSize,
-.mSize,
-.lSize {
+.xsIconSize,
+.sIconSize,
+.mIconSize,
+.lIconSize {
   composes: psIcon;
 }
 
-.xsSize {
+.xsIconSize {
   height: 1rem;
   width: 1rem;
 }
 
-.sSize {
+.sIconSize {
   height: 1.25rem;
   width: 1.25rem;
 }
 
-.mSize {
+.mIconSize {
   height: 1.5rem;
   width: 1.5rem;
 }
 
-.lSize {
+.lIconSize {
   height: 3rem;
   width: 3rem;
 }

--- a/packages/headless-styles/src/components/Icon/iconCSS.ts
+++ b/packages/headless-styles/src/components/Icon/iconCSS.ts
@@ -9,7 +9,7 @@ export function getIconProps(options?: IconOptions) {
   const defaultOptions = getDefaultOptions(options)
   const { size, tech, ...a11y } = defaultOptions
   const a11yProps = getA11yIconProps(a11y)
-  const sizeClass = `${size}Size`
+  const sizeClass = `${size}IconSize`
 
   if (tech === 'svelte') {
     return {

--- a/packages/headless-styles/tests/icon/iconCSS.test.ts
+++ b/packages/headless-styles/tests/icon/iconCSS.test.ts
@@ -4,7 +4,7 @@ describe('Icon CSS', () => {
   describe('getIconProps', () => {
     const baseClass = 'ps-icon'
     const result = {
-      className: `${baseClass} mSize`,
+      className: `${baseClass} mIconSize`,
       role: 'img',
       'aria-hidden': false,
     }
@@ -16,16 +16,16 @@ describe('Icon CSS', () => {
     test('should accept a size type', () => {
       expect(getIconProps({ size: 's' })).toEqual({
         ...result,
-        className: `${baseClass} sSize`,
+        className: `${baseClass} sIconSize`,
       })
       expect(getIconProps({ size: 'xs' })).toEqual({
         ...result,
-        className: `${baseClass} xsSize`,
+        className: `${baseClass} xsIconSize`,
       })
       expect(getIconProps({ size: 'm' })).toEqual(result)
       expect(getIconProps({ size: 'l' })).toEqual({
         ...result,
-        className: `${baseClass} lSize`,
+        className: `${baseClass} lIconSize`,
       })
     })
 
@@ -34,7 +34,7 @@ describe('Icon CSS', () => {
 
       expect(getIconProps({ tech: 'svelte' })).toEqual({
         ...svelteResult,
-        class: `ps-icon psIcon mSize`,
+        class: `ps-icon psIcon mIconSize`,
       })
     })
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #254 
Icon size class names are the same as the ones used for some other components, creating a conflict when exporting classes for svelte

## What is the new behavior?
Icon classes are renamed to be specific to icons.

## Other information
