### PR TITLE
fix(icons): fix tsconfig 'excludes' and merge svelte configs with the…

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -32,13 +32,12 @@
     "build/wrapper.js"
   ],
   "scripts": {
-    "build": "yarn run build:svg && yarn run build:react && yarn run build:svelte && yarn run create:entryFiles",
-    "build:react": "yarn generate:react && tsc --project ./tsconfig.cjs.json",
-    "build:svelte": "yarn generate:svelte && tsc --project ./tsconfig.svelte.json",
+    "build": "yarn run build:svg && yarn run build:react && yarn run build:svelte && yarn run build:ts && yarn run create:entryFiles",
+    "build:ts": "tsc --project ./tsconfig.cjs.json",
+    "build:react": "yarn node ./utils/svgToReact.mjs",
+    "build:svelte": "yarn node ./utils/svgToSvelte.mjs",
     "build:svg": "svgo --recursive --folder src --output build/svg",
     "create:entryFiles": "yarn node ./utils/reactPostbuild.mjs",
-    "generate:react": "yarn node ./utils/svgToReact.mjs",
-    "generate:svelte": "yarn node ./utils/svgToSvelte.mjs",
     "test": "echo \"'yarn test' should be run from root directory.\" && exit 1"
   },
   "dependencies": {

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["build/generated/**/*"],
+  "exclude": [],
   "compilerOptions": {
     "allowJs": true,
     "baseUrl": "src",
     "jsx": "react",
     "outDir": "build",
-    "rootDir": "./build/generated"
+    "rootDir": "./build/generated",
+    "types": ["svelte"]
   }
 }


### PR DESCRIPTION
… rest

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
lint:ts threw errors:
- no files found (excludes 'build' and includes 'build/generated/**/*')
- not recognizing .svelte files

## What is the new behavior?

Set excludes to empty (it's relative to includes, so no issues there)
Merge tsconfig.svelte.json with icons base tsconfig.json

## Other information

Need to specify the project's tsconfig file when linting
`yarn run lint:ts --project ./packages/icons/tsconfig.json`

