### PR TITLE
Refactor/hs icon a11y

### DIFF
--- a/packages/headless-styles/src/components/Button/iconButtonCSS.ts
+++ b/packages/headless-styles/src/components/Button/iconButtonCSS.ts
@@ -28,7 +28,7 @@ export function getIconButtonProps(options?: IconButtonOptions) {
       }),
     },
     iconOptions: {
-      ariaHidden: 'true',
+      ariaHidden: true,
       size: iconButtonSizeMap[size],
     },
   }

--- a/packages/headless-styles/src/components/Icon/shared.ts
+++ b/packages/headless-styles/src/components/Icon/shared.ts
@@ -1,4 +1,4 @@
-import type { IconOptions, IconA11yOptions, Tech, A11yBoolean } from './types'
+import type { IconOptions, IconA11yOptions, Tech } from './types'
 import { IconSize } from '../types'
 
 const a11yRole = 'img'
@@ -10,7 +10,7 @@ const a11yPropMap = {
 export const defaultIconOptions = {
   size: 'm' as IconSize,
   tech: '' as Tech,
-  ariaHidden: 'false' as A11yBoolean,
+  ariaHidden: false,
 }
 
 export function getDefaultIconOptions(options?: IconOptions) {

--- a/packages/headless-styles/src/components/Icon/shared.ts
+++ b/packages/headless-styles/src/components/Icon/shared.ts
@@ -1,12 +1,6 @@
 import type { IconOptions, IconA11yOptions, Tech } from './types'
 import { IconSize } from '../types'
 
-const a11yRole = 'img'
-const a11yPropMap = {
-  ariaHidden: 'aria-hidden',
-  ariaLabel: 'aria-label',
-}
-
 export const defaultIconOptions = {
   size: 'm' as IconSize,
   tech: '' as Tech,
@@ -24,10 +18,10 @@ export function getDefaultIconOptions(options?: IconOptions) {
 
 export function getA11yIconProps(a11yOptions?: IconA11yOptions) {
   return {
-    [a11yPropMap.ariaHidden]: a11yOptions?.ariaHidden,
+    'aria-hidden': a11yOptions?.ariaHidden,
     ...(a11yOptions?.ariaLabel && {
-      [a11yPropMap.ariaLabel]: a11yOptions.ariaLabel,
+      'aria-label': a11yOptions.ariaLabel,
     }),
-    role: a11yRole,
+    role: 'img',
   }
 }

--- a/packages/headless-styles/src/components/Icon/shared.ts
+++ b/packages/headless-styles/src/components/Icon/shared.ts
@@ -4,7 +4,7 @@ import { IconSize } from '../types'
 const a11yRole = 'img'
 const a11yPropMap = {
   ariaHidden: 'aria-hidden',
-  label: 'aria-label',
+  ariaLabel: 'aria-label',
 }
 
 export const defaultIconOptions = {
@@ -18,14 +18,16 @@ export function getDefaultIconOptions(options?: IconOptions) {
     size: options?.size ?? defaultIconOptions.size,
     tech: options?.tech ?? defaultIconOptions.tech,
     ariaHidden: options?.ariaHidden ?? defaultIconOptions.ariaHidden,
-    label: options?.label,
+    ariaLabel: options?.ariaLabel,
   }
 }
 
 export function getA11yIconProps(a11yOptions?: IconA11yOptions) {
   return {
     [a11yPropMap.ariaHidden]: a11yOptions?.ariaHidden,
-    ...(a11yOptions?.label && { [a11yPropMap.label]: a11yOptions.label }),
+    ...(a11yOptions?.ariaLabel && {
+      [a11yPropMap.ariaLabel]: a11yOptions.ariaLabel,
+    }),
     role: a11yRole,
   }
 }

--- a/packages/headless-styles/src/components/Icon/types.ts
+++ b/packages/headless-styles/src/components/Icon/types.ts
@@ -2,7 +2,7 @@ import { IconSize } from '../types'
 
 export interface IconA11yOptions {
   label?: string
-  ariaHidden?: A11yBoolean
+  ariaHidden?: boolean
 }
 
 export interface IconOptions extends IconA11yOptions {
@@ -13,4 +13,3 @@ export interface IconOptions extends IconA11yOptions {
 // types
 
 export type Tech = 'svelte' | ''
-export type A11yBoolean = 'true' | 'false'

--- a/packages/headless-styles/src/components/Icon/types.ts
+++ b/packages/headless-styles/src/components/Icon/types.ts
@@ -1,7 +1,7 @@
 import { IconSize } from '../types'
 
 export interface IconA11yOptions {
-  label?: string
+  ariaLabel?: string
   ariaHidden?: boolean
 }
 

--- a/packages/headless-styles/tests/button/iconButtonCSS.test.ts
+++ b/packages/headless-styles/tests/button/iconButtonCSS.test.ts
@@ -11,7 +11,7 @@ describe('Icon Button CSS', () => {
       },
       iconOptions: {
         size: 'm',
-        ariaHidden: 'true',
+        ariaHidden: true,
       },
     }
 

--- a/packages/headless-styles/tests/icon/iconCSS.test.ts
+++ b/packages/headless-styles/tests/icon/iconCSS.test.ts
@@ -34,8 +34,8 @@ describe('Icon CSS', () => {
       })
     })
 
-    test('should accept a label', () => {
-      expect(getIconProps({ label: 'my label' })).toEqual({
+    test('should accept an ariaLabel', () => {
+      expect(getIconProps({ ariaLabel: 'my label' })).toEqual({
         ...result,
         'aria-label': 'my label',
       })

--- a/packages/headless-styles/tests/icon/iconCSS.test.ts
+++ b/packages/headless-styles/tests/icon/iconCSS.test.ts
@@ -6,7 +6,7 @@ describe('Icon CSS', () => {
     const result = {
       className: `${baseClass} mIconSize`,
       role: 'img',
-      'aria-hidden': 'false',
+      'aria-hidden': false,
     }
 
     test('should allow no props to be passed in', () => {
@@ -42,13 +42,13 @@ describe('Icon CSS', () => {
     })
 
     test('should accept an ariaHidden flag', () => {
-      expect(getIconProps({ ariaHidden: 'true' })).toEqual({
+      expect(getIconProps({ ariaHidden: true })).toEqual({
         ...result,
-        'aria-hidden': 'true',
+        'aria-hidden': true,
       })
-      expect(getIconProps({ ariaHidden: 'false' })).toEqual({
+      expect(getIconProps({ ariaHidden: false })).toEqual({
         ...result,
-        'aria-hidden': 'false',
+        'aria-hidden': false,
       })
     })
   })

--- a/packages/headless-styles/tests/icon/iconJS.test.ts
+++ b/packages/headless-styles/tests/icon/iconJS.test.ts
@@ -3,7 +3,7 @@ import type { IconSize } from '../../src/components/types'
 
 describe('icon JS', () => {
   const baseA11yProps = {
-    'aria-hidden': 'false',
+    'aria-hidden': false,
     role: 'img',
   }
   const sizes: Record<IconSize, string> = {
@@ -48,8 +48,8 @@ describe('icon JS', () => {
   test('should accept an ariaHidden flag', () => {
     const a11yProps = {
       ...baseA11yProps,
-      'aria-hidden': 'true',
+      'aria-hidden': true,
     }
-    expect(getJSIconProps({ ariaHidden: 'true' }).a11yProps).toEqual(a11yProps)
+    expect(getJSIconProps({ ariaHidden: true }).a11yProps).toEqual(a11yProps)
   })
 })

--- a/packages/headless-styles/tests/icon/iconJS.test.ts
+++ b/packages/headless-styles/tests/icon/iconJS.test.ts
@@ -36,13 +36,15 @@ describe('icon JS', () => {
     expect(props.cssProps).toContain(`width: ${sizes['l']}`)
   })
 
-  test('should accept a label', () => {
+  test('should accept an ariaLabel', () => {
     const customLabel = 'custom label'
     const a11yProps = {
       ...baseA11yProps,
       'aria-label': customLabel,
     }
-    expect(getJSIconProps({ label: customLabel }).a11yProps).toEqual(a11yProps)
+    expect(getJSIconProps({ ariaLabel: customLabel }).a11yProps).toEqual(
+      a11yProps
+    )
   })
 
   test('should accept an ariaHidden flag', () => {

--- a/website/docs/development/packages/headless-styles/Button.mdx
+++ b/website/docs/development/packages/headless-styles/Button.mdx
@@ -106,7 +106,7 @@ import { getIconProps } from '@pluralsight/headless-styles'
 import { PencilIcon } from '@pluralsight/icons'
 
 const defaultBtnProps = getButtonProps({ kind: 'medium' })
-const iconProps = getIconProps({ ariaHidden: 'true' })
+const iconProps = getIconProps({ ariaHidden: true })
 
 function EditButton(props) {
   return (

--- a/website/docs/development/packages/headless-styles/Icon.mdx
+++ b/website/docs/development/packages/headless-styles/Icon.mdx
@@ -80,7 +80,7 @@ The icon is purely cosmetic and conveys no real semantic meaning.
 In this case, the icon should be hidden from assistive technology.
 
 ```javascript
-const briefcaseIconProps = getIconProps({ ariaHidden: 'true' })
+const briefcaseIconProps = getIconProps({ ariaHidden: true })
 ```
 
 ### Interactive icons
@@ -142,7 +142,7 @@ export interface IconOptions extends IconA11yOptions {
 ```typescript
 export interface IconA11yOptions {
   label?: string
-  ariaHidden?: 'true' | 'false'
+  ariaHidden?: boolean
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #304 

API argument that maps to aria-label was named `label`
Used a custom type `A11yBoolean` for aria-hidden

## What is the new behavior?

API argument now named `ariaLabel`
A11yBoolean type removed and replaced with boolean primitive

## Other information
