### PR TITLE
refactor(headless-styles): use createClassProp for Button

### DIFF
--- a/packages/headless-styles/src/components/Button/buttonCSS.ts
+++ b/packages/headless-styles/src/components/Button/buttonCSS.ts
@@ -1,14 +1,11 @@
 import type { ClassOptions } from '../../utils/helpers'
 import { createClassProp } from '../../utils/helpers'
+import type { Tech } from '../types'
 import { getDefaultOptions, getDefaultDangerOptions } from './shared'
 import type { ButtonOptions, ButtonType, DangerOptions } from './types'
 import styles from './buttonCSS.module.css'
 
-type AllButtonOptions = ButtonOptions | DangerOptions
-
-function createButton(options: AllButtonOptions, classes: ClassOptions) {
-  const tech = options?.tech ?? ''
-
+function createButton(tech: Tech, classes: ClassOptions) {
   return {
     ...createClassProp(tech, classes),
     type: 'button' as ButtonType,
@@ -22,7 +19,7 @@ export function getDangerButtonProps(options?: DangerOptions) {
   const { kind, size } = defaultOptions
   const dangerKind = `${kind}Danger`
 
-  return createButton(defaultOptions, {
+  return createButton(defaultOptions.tech, {
     defaultClass: `ps-danger-btn ${styles[dangerKind]} ${styles[size]}`,
     svelteClass: `base ${kind}Danger ${size}`,
   })
@@ -32,7 +29,7 @@ export function getButtonProps(options?: ButtonOptions) {
   const defaultOptions = getDefaultOptions(options)
   const { kind, size } = defaultOptions
 
-  return createButton(defaultOptions, {
+  return createButton(defaultOptions.tech, {
     defaultClass: `ps-btn ${styles[kind]} ${styles[size]}`,
     svelteClass: `base ${kind} ${size}`,
   })

--- a/packages/headless-styles/src/components/Button/buttonCSS.ts
+++ b/packages/headless-styles/src/components/Button/buttonCSS.ts
@@ -1,22 +1,16 @@
+import type { ClassOptions } from '../../utils/helpers'
+import { createClassProp } from '../../utils/helpers'
 import { getDefaultOptions, getDefaultDangerOptions } from './shared'
-import { createSvelteObj } from '../../utils/helpers'
 import type { ButtonOptions, ButtonType, DangerOptions } from './types'
 import styles from './buttonCSS.module.css'
 
 type AllButtonOptions = ButtonOptions | DangerOptions
 
-interface ButtonClass {
-  defaultClass: string
-  svelteClass: string
-}
-
-function createButton(options: AllButtonOptions, classes: ButtonClass) {
-  if (options.tech === 'svelte') {
-    return createSvelteObj(classes.svelteClass)
-  }
+function createButton(options: AllButtonOptions, classes: ClassOptions) {
+  const tech = options?.tech ?? ''
 
   return {
-    className: classes.defaultClass,
+    ...createClassProp(tech, classes),
     type: 'button' as ButtonType,
   }
 }

--- a/packages/headless-styles/tests/button/buttonCSS.test.ts
+++ b/packages/headless-styles/tests/button/buttonCSS.test.ts
@@ -51,6 +51,7 @@ describe('Button CSS', () => {
     test('should accept a tech type', () => {
       expect(getButtonProps({ tech: 'svelte' })).toEqual({
         class: 'base text m',
+        type: 'button',
       })
     })
   })
@@ -97,6 +98,7 @@ describe('Button CSS', () => {
     test('should accept a tech type', () => {
       expect(getDangerButtonProps({ tech: 'svelte' })).toEqual({
         class: 'base textDanger m',
+        type: 'button',
       })
     })
   })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Contributes to #312 

## What is the new behavior?

Refactors Button prop getter to use getClassProp.
Also returns `type="button"` for Svelte, which was previously missing

## Other information
