### PR TITLE
refactor(hs): cleanup iconButtonCSS.ts

### DIFF
--- a/packages/headless-styles/sandbox/src/components/IconButton.jsx
+++ b/packages/headless-styles/sandbox/src/components/IconButton.jsx
@@ -1,12 +1,40 @@
 import { getIconButtonProps, getIconProps } from '../../../src'
-import { CodeIcon } from '@pluralsight/icons'
+import {
+  ArrowDownRightIcon,
+  CodeIcon,
+  PluralsightIcon,
+  ShareIcon,
+} from '@pluralsight/icons'
+
+const BTN_KINDS = ['text', 'textWeak', 'weak', 'medium', 'strong']
+const BTN_SIZES = ['xs', 's', 'm', 'l']
+const BTN_ICONS = [ArrowDownRightIcon, CodeIcon, PluralsightIcon, ShareIcon]
+
+function getRandomArrayIdx(arr) {
+  return Math.floor(Math.random() * arr.length)
+}
+
+function getRandomButton() {
+  return {
+    kind: BTN_KINDS[getRandomArrayIdx(BTN_KINDS)],
+    icon: BTN_ICONS[getRandomArrayIdx(BTN_ICONS)],
+    size: BTN_SIZES[getRandomArrayIdx(BTN_SIZES)],
+  }
+}
 
 function PSIconButton(props) {
-  const { button, iconOptions } = getIconButtonProps(props)
+  const btn = getRandomButton()
+  const buttonProps = getIconButtonProps({
+    ...props,
+    ...btn,
+  })
+  const Icon = btn.icon
+
+  console.log(btn, buttonProps)
 
   return (
-    <button {...button}>
-      <CodeIcon {...getIconProps(iconOptions)} />
+    <button {...buttonProps.button}>
+      <Icon {...getIconProps(buttonProps.iconOptions)} />
     </button>
   )
 }
@@ -21,54 +49,18 @@ export default function IconButton() {
       <h3>Icon Button</h3>
       <div className="App-container">
         <PSIconButton ariaLabel="default" />
-        <PSIconButton ariaLabel="textWeak" kind="textWeak" />
-        <PSIconButton ariaLabel="weak" kind="weak" />
-        <PSIconButton ariaLabel="medium" kind="medium" />
-        <PSIconButton ariaLabel="strong" kind="strong" />
-      </div>
-      <div className="App-container">
-        <PSIconButton ariaLabel="extra small" kind="medium" size="xs" />
-        <PSIconButton ariaLabel="small" kind="medium" size="s" />
-        <PSIconButton ariaLabel="medium" kind="medium" size="m" />
-        <PSIconButton ariaLabel="large" kind="medium" size="l" />
+        <PSIconButton ariaLabel="textWeak" />
+        <PSIconButton ariaLabel="weak" />
+        <PSIconButton ariaLabel="medium" />
+        <PSIconButton ariaLabel="strong" />
       </div>
       <h3>Round Icon Button</h3>
       <div className="App-container">
         <PSIconButton ariaLabel="default round" variant="round" />
-        <PSIconButton
-          ariaLabel="textWeak round"
-          kind="textWeak"
-          variant="round"
-        />
-        <PSIconButton ariaLabel="weak round" kind="weak" variant="round" />
-        <PSIconButton ariaLabel="medium round" kind="medium" variant="round" />
-        <PSIconButton ariaLabel="strong round" kind="strong" variant="round" />
-      </div>
-      <div className="App-container">
-        <PSIconButton
-          ariaLabel="extra small round"
-          kind="medium"
-          size="xs"
-          variant="round"
-        />
-        <PSIconButton
-          ariaLabel="small round"
-          kind="medium"
-          size="s"
-          variant="round"
-        />
-        <PSIconButton
-          ariaLabel="medium round"
-          kind="medium"
-          size="m"
-          variant="round"
-        />
-        <PSIconButton
-          ariaLabel="large round"
-          kind="medium"
-          size="l"
-          variant="round"
-        />
+        <PSIconButton ariaLabel="textWeak round" variant="round" />
+        <PSIconButton ariaLabel="weak round" variant="round" />
+        <PSIconButton ariaLabel="medium round" variant="round" />
+        <PSIconButton ariaLabel="strong round" variant="round" />
       </div>
     </div>
   )

--- a/packages/headless-styles/src/components/Button/iconButtonCSS.ts
+++ b/packages/headless-styles/src/components/Button/iconButtonCSS.ts
@@ -1,35 +1,22 @@
 import { createClassProp } from '../../utils/helpers'
-import type { IconSize } from '../types'
-import type { ButtonType, IconButtonOptions, Size } from './types'
-import { getDefaultIconButtonOptions } from './shared'
+import { getDefaultIconButtonOptions, getIconButtonReturnProps } from './shared'
+import type { IconButtonOptions } from './types'
 import styles from './buttonCSS.module.css'
-
-// Public
-
-const iconButtonSizeMap: Record<Size, IconSize> = {
-  xs: 's',
-  s: 'm',
-  m: 'm',
-  l: 'l',
-}
 
 export function getIconButtonProps(options?: IconButtonOptions) {
   const defaultOptions = getDefaultIconButtonOptions(options)
-  const { kind, size, variant, ariaLabel, tech } = defaultOptions
-  const sizeClass = `${size}IconButton`
+  const { kind, variant } = defaultOptions
+  const sizeClass = `${defaultOptions.size}IconButton`
+  const props = getIconButtonReturnProps(defaultOptions)
 
   return {
+    ...props,
     button: {
-      'aria-label': ariaLabel,
-      type: 'button' as ButtonType,
-      ...createClassProp(tech, {
+      ...props.button,
+      ...createClassProp(defaultOptions.tech, {
         defaultClass: `ps-icon-btn ${styles[kind]} ${styles[sizeClass]} ${styles[variant]}`,
         svelteClass: `base ${kind} ${sizeClass} ${variant}`,
       }),
-    },
-    iconOptions: {
-      ariaHidden: true,
-      size: iconButtonSizeMap[size],
     },
   }
 }

--- a/packages/headless-styles/src/components/Button/shared.ts
+++ b/packages/headless-styles/src/components/Button/shared.ts
@@ -1,4 +1,4 @@
-import type { Tech } from '../types'
+import type { IconSize, Tech } from '../types'
 import type {
   ButtonOptions,
   DangerOptions,
@@ -7,6 +7,7 @@ import type {
   Kind,
   Size,
   Variant,
+  ButtonType,
 } from './types'
 
 export const defaultButtonOptions = {
@@ -52,5 +53,25 @@ export function getDefaultIconButtonOptions(options?: IconButtonOptions) {
     tech: options?.tech ?? defaultIconButtonOptions.tech,
     ariaLabel: options?.ariaLabel ?? defaultIconButtonOptions.ariaLabel,
     variant: options?.variant ?? defaultIconButtonOptions.variant,
+  }
+}
+
+export function getIconButtonReturnProps(options: IconButtonOptions) {
+  const iconButtonSizeMap: Record<Size, IconSize> = {
+    xs: 's',
+    s: 'm',
+    m: 'm',
+    l: 'l',
+  }
+
+  return {
+    button: {
+      'aria-label': options.ariaLabel,
+      type: 'button' as ButtonType,
+    },
+    iconOptions: {
+      ariaHidden: true,
+      size: iconButtonSizeMap[options.size as Size],
+    },
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes to #172 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Cleans up iconButtonCSS to use same pattern as newer helpers.

## Other information
@Rykus0 I'm comfortable with keeping the Icon Button logic in the Button directory and this API now that I've hammered it pretty hard in the sandbox. Go ahead and kill that other PR and add your JS API here.

We can and should still make the Icon Button a separate docs page though. 👍 