### PR TITLE
refactor(headless-styles): use simpler, more robust icon button styles

### DIFF
--- a/packages/headless-styles/src/components/Button/buttonCSS.module.css
+++ b/packages/headless-styles/src/components/Button/buttonCSS.module.css
@@ -13,6 +13,7 @@
   font-weight: 600;
   height: 2.5rem;
   justify-content: center;
+  min-width: 2.5rem;
   outline: none;
   padding-inline: 16px;
   position: relative;
@@ -57,6 +58,7 @@
   composes: base;
   font-size: 0.75rem;
   height: 1.5rem;
+  min-width: 1.5rem;
   padding-inline: 8px;
 }
 
@@ -64,37 +66,15 @@
   composes: base;
   font-size: 0.875rem;
   height: 2rem;
+  min-width: 2rem;
   padding-inline: 12px;
 }
 
 .l {
   composes: base;
   height: 3rem;
+  min-width: 3rem;
   padding-inline: 24px;
-}
-
-.xsIconButton {
-  composes: xs;
-  padding-inline: 0;
-  width: 1.5rem;
-}
-
-.sIconButton {
-  composes: s;
-  padding-inline: 0;
-  width: 2rem;
-}
-
-.mIconButton {
-  composes: base;
-  padding-inline: 0;
-  width: 2.5rem;
-}
-
-.lIconButton {
-  composes: l;
-  padding-inline: 0;
-  width: 3rem;
 }
 
 .textDanger {
@@ -112,6 +92,13 @@
   background-color: var(--ps-danger-background-weak);
   color: var(--ps-danger-text);
   composes: base;
+}
+
+.xs.iconButton,
+.s.iconButton,
+.m.iconButton,
+.l.iconButton {
+  padding-inline: 0;
 }
 
 .round {

--- a/packages/headless-styles/src/components/Button/iconButtonCSS.ts
+++ b/packages/headless-styles/src/components/Button/iconButtonCSS.ts
@@ -6,7 +6,7 @@ import styles from './buttonCSS.module.css'
 export function getIconButtonProps(options?: IconButtonOptions) {
   const defaultOptions = getDefaultIconButtonOptions(options)
   const { kind, variant } = defaultOptions
-  const sizeClass = `${defaultOptions.size}IconButton`
+  const sizeClass = `${defaultOptions.size}`
   const props = getIconButtonReturnProps(defaultOptions)
 
   return {
@@ -14,8 +14,8 @@ export function getIconButtonProps(options?: IconButtonOptions) {
     button: {
       ...props.button,
       ...createClassProp(defaultOptions.tech, {
-        defaultClass: `ps-icon-btn ${styles[kind]} ${styles[sizeClass]} ${styles[variant]}`,
-        svelteClass: `base ${kind} ${sizeClass} ${variant}`,
+        defaultClass: `ps-icon-btn ${styles.iconButton} ${styles[kind]} ${styles[sizeClass]} ${styles[variant]}`,
+        svelteClass: `base iconButton ${kind} ${sizeClass} ${variant}`,
       }),
     },
   }

--- a/packages/headless-styles/src/components/Button/shared.ts
+++ b/packages/headless-styles/src/components/Button/shared.ts
@@ -72,6 +72,7 @@ export function getIconButtonReturnProps(options: IconButtonOptions) {
     iconOptions: {
       ariaHidden: true,
       size: iconButtonSizeMap[options.size as Size],
+      tech: options.tech,
     },
   }
 }

--- a/packages/headless-styles/tests/button/iconButtonCSS.test.ts
+++ b/packages/headless-styles/tests/button/iconButtonCSS.test.ts
@@ -12,6 +12,7 @@ describe('Icon Button CSS', () => {
       iconOptions: {
         size: 'm',
         ariaHidden: true,
+        tech: '',
       },
     }
 
@@ -103,7 +104,7 @@ describe('Icon Button CSS', () => {
           type: 'button',
           class: 'base iconButton text m default',
         },
-        iconOptions: result.iconOptions,
+        iconOptions: { ...result.iconOptions, tech: 'svelte' },
       })
     })
 

--- a/packages/headless-styles/tests/button/iconButtonCSS.test.ts
+++ b/packages/headless-styles/tests/button/iconButtonCSS.test.ts
@@ -2,11 +2,11 @@ import { getIconButtonProps } from '../../src'
 
 describe('Icon Button CSS', () => {
   describe('getIconButtonProps', () => {
-    const baseClass = 'ps-icon-btn'
+    const baseClass = 'ps-icon-btn iconButton'
     const result = {
       button: {
         'aria-label': 'button',
-        className: `${baseClass} text mIconButton default`,
+        className: `${baseClass} text m default`,
         type: 'button',
       },
       iconOptions: {
@@ -28,7 +28,7 @@ describe('Icon Button CSS', () => {
       ).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} textWeak mIconButton default`,
+          className: `${baseClass} textWeak m default`,
         },
         iconOptions: result.iconOptions,
       })
@@ -36,7 +36,7 @@ describe('Icon Button CSS', () => {
         {
           button: {
             ...result.button,
-            className: `${baseClass} weak mIconButton default`,
+            className: `${baseClass} weak m default`,
           },
           iconOptions: result.iconOptions,
         }
@@ -46,7 +46,7 @@ describe('Icon Button CSS', () => {
       ).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} medium mIconButton default`,
+          className: `${baseClass} medium m default`,
         },
         iconOptions: result.iconOptions,
       })
@@ -55,7 +55,7 @@ describe('Icon Button CSS', () => {
       ).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} strong mIconButton default`,
+          className: `${baseClass} strong m default`,
         },
         iconOptions: result.iconOptions,
       })
@@ -68,7 +68,7 @@ describe('Icon Button CSS', () => {
       expect(getIconButtonProps({ ariaLabel: 'button', size: 'xs' })).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} text xsIconButton default`,
+          className: `${baseClass} text xs default`,
         },
         iconOptions: {
           ...result.iconOptions,
@@ -78,14 +78,14 @@ describe('Icon Button CSS', () => {
       expect(getIconButtonProps({ ariaLabel: 'button', size: 's' })).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} text sIconButton default`,
+          className: `${baseClass} text s default`,
         },
         iconOptions: result.iconOptions,
       })
       expect(getIconButtonProps({ ariaLabel: 'button', size: 'l' })).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} text lIconButton default`,
+          className: `${baseClass} text l default`,
         },
         iconOptions: {
           ...result.iconOptions,
@@ -101,7 +101,7 @@ describe('Icon Button CSS', () => {
         button: {
           'aria-label': 'button',
           type: 'button',
-          class: 'base text mIconButton default',
+          class: 'base iconButton text m default',
         },
         iconOptions: result.iconOptions,
       })
@@ -113,7 +113,7 @@ describe('Icon Button CSS', () => {
       ).toEqual({
         button: {
           ...result.button,
-          className: `${baseClass} text mIconButton round`,
+          className: `${baseClass} text m round`,
         },
         iconOptions: result.iconOptions,
       })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #172 

## What is the new behavior?

Simplifies icon button classes.  Instead of using separate size classes for icon button, now use a single class and compose - this also more clearly ensures the base styles are overridden.

Adds a min-width for a slightly more robust sizing across all styles.

Includes `tech` in the returned iconOptions to simplify usage.

## Other information
