### PR TITLE
feat(hs): add remaining kind styles to Alert CSS

### DIFF
--- a/packages/headless-styles/sandbox/src/components/Alert.jsx
+++ b/packages/headless-styles/sandbox/src/components/Alert.jsx
@@ -2,7 +2,7 @@ import { getAlertProps, getIconProps, getIconButtonProps } from '../../../src'
 import { CloseIcon, InfoCircleIcon } from '@pluralsight/icons'
 
 function AlertEl(props) {
-  const alert = getAlertProps(props.kind)
+  const alert = getAlertProps({ kind: props.kind })
   const { button, iconOptions } = getIconButtonProps(alert.iconButtonOptions)
 
   return (
@@ -37,6 +37,24 @@ export default function Alert() {
           alertTitle="Info alert"
           description="This is an example has a close button."
           showButton
+        />
+        <br />
+        <AlertEl
+          alertTitle="Success alert"
+          description="Your information was saved."
+          kind="success"
+        />
+        <br />
+        <AlertEl
+          alertTitle="Warning alert"
+          description="Your changes have not been saved. Proceed with caution."
+          kind="warning"
+        />
+        <br />
+        <AlertEl
+          alertTitle="Danger alert"
+          description="Your file has been permanently deleted."
+          kind="danger"
         />
       </div>
     </div>

--- a/packages/headless-styles/src/components/Alert/alertCSS.module.css
+++ b/packages/headless-styles/src/components/Alert/alertCSS.module.css
@@ -26,7 +26,7 @@
 }
 
 .text {
-  color: var(--ps-info-text);
+  color: inherit;
   font-family: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,
     sans-serif;
   text-align: left;
@@ -49,7 +49,6 @@
 }
 
 .alertIconWrapper {
-  color: var(--ps-info-text-medium);
   display: inline-block;
   margin-inline-end: 0.875rem;
   padding-top: 0.875rem;
@@ -61,8 +60,81 @@
   flex-direction: column;
 }
 
-/* kinds */
+/* info */
 
 .infoAlert {
   composes: alertWrapper;
+}
+
+.infoIconWrapper {
+  color: var(--ps-info-text-medium);
+  composes: alertIconWrapper;
+}
+
+.infoTextContainer {
+  color: var(--ps-info-text);
+  composes: alertTextContainer;
+}
+
+/* success */
+
+.successAlert {
+  background: var(--ps-success-background-weak);
+  composes: alertWrapper;
+}
+
+.successAlert::before {
+  background-color: var(--ps-success-border);
+}
+
+.successIconWrapper {
+  color: var(--ps-success-text-medium);
+  composes: alertIconWrapper;
+}
+
+.successTextContainer {
+  color: var(--ps-success-text);
+  composes: alertTextContainer;
+}
+
+/* warning */
+
+.warningAlert {
+  background: var(--ps-warning-background-weak);
+  composes: alertWrapper;
+}
+
+.warningAlert::before {
+  background-color: var(--ps-warning-border);
+}
+
+.warningIconWrapper {
+  color: var(--ps-warning-text-medium);
+  composes: alertIconWrapper;
+}
+
+.warningTextContainer {
+  color: var(--ps-warning-text);
+  composes: alertTextContainer;
+}
+
+/* danger */
+
+.dangerAlert {
+  background: var(--ps-danger-background-weak);
+  composes: alertWrapper;
+}
+
+.dangerAlert::before {
+  background-color: var(--ps-danger-border);
+}
+
+.dangerIconWrapper {
+  color: var(--ps-danger-text-medium);
+  composes: alertIconWrapper;
+}
+
+.dangerTextContainer {
+  color: var(--ps-danger-text);
+  composes: alertTextContainer;
 }

--- a/packages/headless-styles/src/components/Alert/alertCSS.module.css
+++ b/packages/headless-styles/src/components/Alert/alertCSS.module.css
@@ -25,7 +25,7 @@
   z-index: 50;
 }
 
-.text {
+.alertText {
   color: inherit;
   font-family: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,
     sans-serif;
@@ -33,7 +33,7 @@
 }
 
 .alertDescription {
-  composes: text;
+  composes: alertText;
   font-size: 0.875rem;
   font-variation-settings: 'wght' 400;
   font-weight: 400;
@@ -41,7 +41,7 @@
 }
 
 .alertTitle {
-  composes: text;
+  composes: alertText;
   font-size: 1rem;
   font-variation-settings: 'wght' 600;
   font-weight: 600;

--- a/packages/headless-styles/src/components/Alert/alertCSS.ts
+++ b/packages/headless-styles/src/components/Alert/alertCSS.ts
@@ -9,6 +9,8 @@ export function getAlertProps(options?: AlertOptions) {
   const { kind, tech } = getDefaultAlertOptions(options)
   const props = createAlertProps()
   const kindClass = `${kind}Alert`
+  const iconClass = `${kind}IconWrapper`
+  const textClass = `${kind}TextContainer`
 
   return {
     ...props,
@@ -22,15 +24,15 @@ export function getAlertProps(options?: AlertOptions) {
     iconWrapper: {
       ...props.iconWrapper,
       ...createClassProp(tech, {
-        svelteClass: `${ALERT}-icon alertIconWrapper`,
-        defaultClass: `${ALERT}-icon ${styles.alertIconWrapper}`,
+        svelteClass: `${ALERT}-icon ${iconClass}`,
+        defaultClass: `${ALERT}-icon ${styles[iconClass]}`,
       }),
     },
     textContainer: {
       ...props.textContainer,
       ...createClassProp(tech, {
-        svelteClass: `${ALERT}-text-container alertTextContainer`,
-        defaultClass: `${ALERT}-text-container ${styles.alertTextContainer}`,
+        svelteClass: `${ALERT}-text-container ${textClass}`,
+        defaultClass: `${ALERT}-text-container ${styles[textClass]}`,
       }),
     },
     title: {

--- a/packages/headless-styles/src/components/Alert/alertCSS.ts
+++ b/packages/headless-styles/src/components/Alert/alertCSS.ts
@@ -24,14 +24,14 @@ export function getAlertProps(options?: AlertOptions) {
     iconWrapper: {
       ...props.iconWrapper,
       ...createClassProp(tech, {
-        svelteClass: `${ALERT}-icon ${iconClass}`,
+        svelteClass: `${ALERT}-icon alertIconWrapper ${iconClass}`,
         defaultClass: `${ALERT}-icon ${styles[iconClass]}`,
       }),
     },
     textContainer: {
       ...props.textContainer,
       ...createClassProp(tech, {
-        svelteClass: `${ALERT}-text-container ${textClass}`,
+        svelteClass: `${ALERT}-text-container alertTextContainer ${textClass}`,
         defaultClass: `${ALERT}-text-container ${styles[textClass]}`,
       }),
     },
@@ -45,7 +45,7 @@ export function getAlertProps(options?: AlertOptions) {
     wrapper: {
       ...props.wrapper,
       ...createClassProp(tech, {
-        svelteClass: `${ALERT} ${kindClass}`,
+        svelteClass: `${ALERT} alertWrapper ${kindClass}`,
         defaultClass: `${ALERT} ${styles[kindClass]}`,
       }),
     },

--- a/packages/headless-styles/src/components/Alert/generated/alertCSS.module.ts
+++ b/packages/headless-styles/src/components/Alert/generated/alertCSS.module.ts
@@ -30,7 +30,7 @@ export default {
     },
   },
   text: {
-    color: 'hsl(201deg 100% 92% / 100%)',
+    color: 'inherit',
     fontFamily:
       "'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,\n    sans-serif",
     textAlign: 'left',
@@ -50,7 +50,6 @@ export default {
     paddingTop: '0.875rem',
   },
   alertIconWrapper: {
-    color: 'hsl(202deg 100% 58% / 100%)',
     display: 'inline-block',
     marginInlineEnd: '0.875rem',
     paddingTop: '0.875rem',
@@ -62,5 +61,58 @@ export default {
   },
   infoAlert: {
     composes: 'alertWrapper',
+  },
+  infoIconWrapper: {
+    color: 'hsl(202deg 100% 58% / 100%)',
+    composes: 'alertIconWrapper',
+  },
+  infoTextContainer: {
+    color: 'hsl(201deg 100% 92% / 100%)',
+    composes: 'alertTextContainer',
+  },
+  successAlert: {
+    background: 'hsl(156deg 97% 15% / 100%)',
+    composes: 'alertWrapper',
+    '&::before': {
+      backgroundColor: 'hsl(156deg 98% 44% / 100%)',
+    },
+  },
+  successIconWrapper: {
+    color: 'hsl(156deg 98% 37% / 100%)',
+    composes: 'alertIconWrapper',
+  },
+  successTextContainer: {
+    color: 'hsl(156deg 100% 91% / 100%)',
+    composes: 'alertTextContainer',
+  },
+  warningAlert: {
+    background: 'hsl(43deg 100% 21% / 100%)',
+    composes: 'alertWrapper',
+    '&::before': {
+      backgroundColor: 'hsl(43deg 100% 53% / 100%)',
+    },
+  },
+  warningIconWrapper: {
+    color: 'hsl(43deg 100% 69% / 100%)',
+    composes: 'alertIconWrapper',
+  },
+  warningTextContainer: {
+    color: 'hsl(43deg 100% 94% / 100%)',
+    composes: 'alertTextContainer',
+  },
+  dangerAlert: {
+    background: 'hsl(335deg 100% 18% / 100%)',
+    composes: 'alertWrapper',
+    '&::before': {
+      backgroundColor: 'hsl(336deg 100% 54% / 100%)',
+    },
+  },
+  dangerIconWrapper: {
+    color: 'hsl(336deg 100% 73% / 100%)',
+    composes: 'alertIconWrapper',
+  },
+  dangerTextContainer: {
+    color: 'hsl(336deg 100% 97% / 100%)',
+    composes: 'alertTextContainer',
   },
 }

--- a/packages/headless-styles/src/components/Alert/generated/alertCSS.module.ts
+++ b/packages/headless-styles/src/components/Alert/generated/alertCSS.module.ts
@@ -29,21 +29,21 @@ export default {
       zIndex: '50',
     },
   },
-  text: {
+  alertText: {
     color: 'inherit',
     fontFamily:
       "'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial,\n    sans-serif",
     textAlign: 'left',
   },
   alertDescription: {
-    composes: 'text',
+    composes: 'alertText',
     fontSize: '0.875rem',
     fontVariationSettings: "'wght' 400",
     fontWeight: '400',
     marginTop: '4px',
   },
   alertTitle: {
-    composes: 'text',
+    composes: 'alertText',
     fontSize: '1rem',
     fontVariationSettings: "'wght' 600",
     fontWeight: '600',

--- a/packages/headless-styles/tests/alert/alertCSS.test.ts
+++ b/packages/headless-styles/tests/alert/alertCSS.test.ts
@@ -16,10 +16,10 @@ describe('Alert CSS', () => {
         className: `${baseClass}-description alertDescription`,
       },
       iconWrapper: {
-        className: `${baseClass}-icon alertIconWrapper`,
+        className: `${baseClass}-icon infoIconWrapper`,
       },
       textContainer: {
-        className: `${baseClass}-text-container alertTextContainer`,
+        className: `${baseClass}-text-container infoTextContainer`,
       },
       title: {
         className: `${baseClass}-title alertTitle`,
@@ -34,8 +34,62 @@ describe('Alert CSS', () => {
       expect(getAlertProps()).toEqual(result)
     })
 
-    test('should accept a kind type', () => {
+    test('should accept a info kind type', () => {
       expect(getAlertProps({ kind: 'info' })).toEqual(result)
+    })
+
+    test('should accept a success kind type', () => {
+      expect(getAlertProps({ kind: 'success' })).toEqual({
+        ...result,
+        iconWrapper: {
+          ...result.iconWrapper,
+          className: `${baseClass}-icon successIconWrapper`,
+        },
+        textContainer: {
+          ...result.textContainer,
+          className: `${baseClass}-text-container successTextContainer`,
+        },
+        wrapper: {
+          ...result.wrapper,
+          className: `${baseClass} successAlert`,
+        },
+      })
+    })
+
+    test('should accept a warning kind type', () => {
+      expect(getAlertProps({ kind: 'warning' })).toEqual({
+        ...result,
+        iconWrapper: {
+          ...result.iconWrapper,
+          className: `${baseClass}-icon warningIconWrapper`,
+        },
+        textContainer: {
+          ...result.textContainer,
+          className: `${baseClass}-text-container warningTextContainer`,
+        },
+        wrapper: {
+          ...result.wrapper,
+          className: `${baseClass} warningAlert`,
+        },
+      })
+    })
+
+    test('should accept a danger kind type', () => {
+      expect(getAlertProps({ kind: 'danger' })).toEqual({
+        ...result,
+        iconWrapper: {
+          ...result.iconWrapper,
+          className: `${baseClass}-icon dangerIconWrapper`,
+        },
+        textContainer: {
+          ...result.textContainer,
+          className: `${baseClass}-text-container dangerTextContainer`,
+        },
+        wrapper: {
+          ...result.wrapper,
+          className: `${baseClass} dangerAlert`,
+        },
+      })
     })
 
     test('should accept a tech type', () => {
@@ -52,10 +106,10 @@ describe('Alert CSS', () => {
           class: `${baseClass}-description alertDescription`,
         },
         iconWrapper: {
-          class: `${baseClass}-icon alertIconWrapper`,
+          class: `${baseClass}-icon infoIconWrapper`,
         },
         textContainer: {
-          class: `${baseClass}-text-container alertTextContainer`,
+          class: `${baseClass}-text-container infoTextContainer`,
         },
         title: {
           class: `${baseClass}-title alertTitle`,

--- a/packages/headless-styles/tests/alert/alertCSS.test.ts
+++ b/packages/headless-styles/tests/alert/alertCSS.test.ts
@@ -106,16 +106,16 @@ describe('Alert CSS', () => {
           class: `${baseClass}-description alertDescription`,
         },
         iconWrapper: {
-          class: `${baseClass}-icon infoIconWrapper`,
+          class: `${baseClass}-icon alertIconWrapper infoIconWrapper`,
         },
         textContainer: {
-          class: `${baseClass}-text-container infoTextContainer`,
+          class: `${baseClass}-text-container alertTextContainer infoTextContainer`,
         },
         title: {
           class: `${baseClass}-title alertTitle`,
         },
         wrapper: {
-          class: `${baseClass} infoAlert`,
+          class: `${baseClass} alertWrapper infoAlert`,
           role: 'alert',
         },
       })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes #406 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Adds remaining kind styles to CSS module for Alert

## Other information
![Screen Shot 2022-07-07 at 2 09 43 PM](https://user-images.githubusercontent.com/4819738/177855768-ddb61a28-f505-42f7-9192-89340c80cd2d.png)
