### PR TITLE
fix(headless-styles): add base hover decoration for tag

### DIFF
--- a/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
+++ b/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
@@ -28,6 +28,9 @@ export default {
     transition: 'background-color 250ms ease-in-out, color 250ms ease-in-out',
     verticalAlign: 'middle',
     whiteSpace: 'nowrap',
+    '&:hover': {
+      textDecoration: 'none',
+    },
     '&:focus': {
       boxShadow: 'none',
       outline: '3px solid hsl(249deg 63% 34% / 100%)',

--- a/packages/headless-styles/src/components/Tag/tagCSS.module.css
+++ b/packages/headless-styles/src/components/Tag/tagCSS.module.css
@@ -43,6 +43,9 @@
 }
 
 /* hover styles */
+.baseTag:hover {
+  text-decoration: none;
+}
 
 .strongTag:hover {
   background-color: var(--ps-background-weak-hover);

--- a/packages/headless-styles/src/components/Tag/tagJS.ts
+++ b/packages/headless-styles/src/components/Tag/tagJS.ts
@@ -4,6 +4,7 @@ import type { TagOptions } from './types'
 import styles from './generated/tagCSS.module'
 
 type StylesKey = keyof typeof styles
+type KindKey = 'weakTag' | 'strongTag'
 
 export function getJSTagProps(options?: TagOptions) {
   const defaultOptions = getDefaultTagOptions(options)
@@ -11,10 +12,19 @@ export function getJSTagProps(options?: TagOptions) {
     defaultOptions.kind,
     defaultOptions.size
   )
+  const kindStyles = styles[kindClass as KindKey]
   const JsStyles = {
     ...styles.baseTag,
-    ...styles[kindClass as StylesKey],
+    ...kindStyles,
     ...styles[sizeClass as StylesKey],
+    '&:active': {
+      ...styles.baseTag['&:active'],
+      ...kindStyles['&:active'],
+    },
+    '&:hover': {
+      ...styles.baseTag['&:hover'],
+      ...kindStyles['&:hover'],
+    },
   }
 
   return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #426 

Base typography styles are being applied on hover, resulting in an underline.

## What is the new behavior?
Explicitly sets the `text-decoration` on hover to override any styles applied to the `a` tag

## Other information
Next (and final) step is updating the HS dependency in the docs