### PR TITLE
refactor(react-utils): rename initFocusTrap to setupFocusTrap

### DIFF
--- a/packages/react-utils/src/hooks/useFocusTrap.ts
+++ b/packages/react-utils/src/hooks/useFocusTrap.ts
@@ -59,7 +59,7 @@ export function useFocusTrap(triggerRef: RefObject<HTMLButtonElement>) {
 
   return {
     ref: modalRef,
-    initFocusTrap: handleInitFocusTrap,
+    setupFocusTrap: handleInitFocusTrap,
     onKeydown: handleFocus,
   }
 }

--- a/packages/react-utils/tests/hooks/useFocusTrap.test.tsx
+++ b/packages/react-utils/tests/hooks/useFocusTrap.test.tsx
@@ -51,7 +51,7 @@ describe('useFocusTrap', () => {
   function AlertDialog(props: AlertProps) {
     const { onClose } = props
     const wrapperRef = useRef(null)
-    const { ref, onKeydown, initFocusTrap } = useFocusTrap(props.triggerRef)
+    const { ref, onKeydown, setupFocusTrap } = useFocusTrap(props.triggerRef)
 
     function handleBackdropClick(event: SyntheticEvent) {
       event.stopPropagation()
@@ -61,8 +61,8 @@ describe('useFocusTrap', () => {
     }
 
     useEffect(() => {
-      initFocusTrap()
-    }, [initFocusTrap])
+      setupFocusTrap()
+    }, [setupFocusTrap])
 
     useEffect(() => {
       function handleEscClose(event: KeyboardEvent) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The return function from `useFocusTrap` is using outdated naming that may confuse new developers.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates the name `initFocusTrap` to instead use `setupFocusTrap` to make it easier to understand what it does.

## Other information
