### PR TITLE
Docs/icon custom size

### DIFF
--- a/website/docs/development/headless-styles/Icon.mdx
+++ b/website/docs/development/headless-styles/Icon.mdx
@@ -70,7 +70,7 @@ We use the standard clothing size shorthand values for all `size` related option
 
 #### Custom sizes
 
-When you need something other than one of the standard icon sizes, you can pass a CSS size string to the `customSize` prop.
+When you need a size that is different from the initial options, you can pass a [length value](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#lengths) to the `customSize` option.
 
 ```jsx live
 function CustomIconSize() {

--- a/website/docs/development/headless-styles/Icon.mdx
+++ b/website/docs/development/headless-styles/Icon.mdx
@@ -201,6 +201,7 @@ This interface is available as an `import` for use.
 
 ```typescript
 export interface IconOptions extends IconA11yOptions {
+  customSize?: string
   size?: 's' | 'm' | 'l'
   tech?: 'svelte'
 }
@@ -235,8 +236,10 @@ interface IconA11yProps {
 
 ```typescript
 interface IconProps {
-  className: string
   ...IconA11yProps
+  className: string
+  height?: string
+  width?: string
 }
 ```
 

--- a/website/docs/development/headless-styles/Icon.mdx
+++ b/website/docs/development/headless-styles/Icon.mdx
@@ -68,6 +68,22 @@ We use the standard clothing size shorthand values for all `size` related option
 
 :::
 
+#### Custom sizes
+
+When you need something other than one of the standard icon sizes, you can pass a CSS size string to the `customSize` prop.
+
+```jsx live
+function CustomIconSize() {
+  return (
+    <PlaceholderIcon
+      {...getIconProps({
+        customSize: '2rem',
+      })}
+    />
+  )
+}
+```
+
 ## Accessibility
 
 An icon alone does not convey any useful information to non-visual users.

--- a/website/docs/development/headless-styles/Tag.mdx
+++ b/website/docs/development/headless-styles/Tag.mdx
@@ -7,21 +7,11 @@ tags: [Development, Packages, Components, Headless Styles, Tag]
 <!-- https://docusaurus.io/docs/markdown-features/code-blocks#imports -->
 
 import CodeBlock from '@theme/CodeBlock'
-import BasicTag from '@site/src/components/Tag/BasicTag'
-import {
-  BasicTagPreview,
-  BasicTagFullPreview,
-} from '@site/src/components/Tag/BasicTag.preview'
 import TagSizes from '@site/src/components/Tag/TagSizes'
 import {
   TagSizesPreview,
   TagSizesFullPreview,
 } from '@site/src/components/Tag/TagSizes.preview'
-import TagWithIcon from '@site/src/components/Tag/TagWithIcon'
-import {
-  TagWithIconPreview,
-  TagWithIconFullPreview,
-} from '@site/src/components/Tag/TagWithIcon.preview'
 import ViewSourceLink from '@site/src/components/ViewSourceLink/ViewSourceLink'
 import LiveExampleTabs from '@site/src/components/LiveExampleTabs/LiveExampleTabs'
 import ReleaseNote from '@site/src/components/Admonitions/_hs-release-note.mdx'

--- a/website/src/components/Icons/InteractiveIcon.js
+++ b/website/src/components/Icons/InteractiveIcon.js
@@ -16,7 +16,14 @@ const linkProps = getButtonProps()
 function InteractiveIcon() {
   return (
     <Container>
-      <div style={{ display: 'flex' }}>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: '1em',
+          justifyContent: 'space-between',
+        }}
+      >
         <a className={button.className} href="/">
           <HomeIcon {...homeIconProps} />
         </a>

--- a/website/src/components/Icons/InteractiveIcon.js
+++ b/website/src/components/Icons/InteractiveIcon.js
@@ -16,30 +16,21 @@ const linkProps = getButtonProps()
 function InteractiveIcon() {
   return (
     <Container>
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          gap: '1em',
-          justifyContent: 'space-between',
-        }}
-      >
-        <a className={button.className} href="/">
-          <HomeIcon {...homeIconProps} />
-        </a>
-        <a href="#" className={linkProps.className}>
-          Page 1
-        </a>
-        <a href="#" className={linkProps.className}>
-          Page 2
-        </a>
-        <a href="#" className={linkProps.className}>
-          Page 3
-        </a>
-        <a href="#" className={linkProps.className}>
-          Page 4
-        </a>
-      </div>
+      <a className={button.className} href="/">
+        <HomeIcon {...homeIconProps} />
+      </a>
+      <a href="#" className={linkProps.className}>
+        Page 1
+      </a>
+      <a href="#" className={linkProps.className}>
+        Page 2
+      </a>
+      <a href="#" className={linkProps.className}>
+        Page 3
+      </a>
+      <a href="#" className={linkProps.className}>
+        Page 4
+      </a>
     </Container>
   )
 }

--- a/website/src/theme/ReactLiveScope/index.js
+++ b/website/src/theme/ReactLiveScope/index.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { getIconProps } from '@pluralsight/headless-styles'
+import { PlaceholderIcon } from '@pluralsight/icons'
+
+const ReactLiveScope = {
+  React,
+  ...React,
+  getIconProps,
+  PlaceholderIcon,
+}
+
+export default ReactLiveScope


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #508 

## What is the new behavior?

Adds `customSize` prop documentation to `getIconProps` API docs

## Other information

Adds `getIconProps` and `PlaceholderIcon` to React live example scope.  Per [Docusaurus Issue #2807](https://github.com/facebook/docusaurus/issues/2807).  Associated [Docusaurus PR](https://github.com/facebook/docusaurus/pull/2826)

Fixes warnings due to unused imports in Tag documentation

Fixes up styles for "interactive icon" example
