### PR TITLE
feat(headless-styles): return null instead of props for disabled feature

### DIFF
--- a/packages/headless-styles/src/components/Menu/menuCSS.ts
+++ b/packages/headless-styles/src/components/Menu/menuCSS.ts
@@ -9,7 +9,7 @@ export function UNSAFE_getMenuProps(options?: MenuOptions) {
   const props = createMenuProps(defaultOptions)
 
   if (!menu) {
-    return props
+    return null
   }
 
   return {

--- a/packages/headless-styles/src/components/Menu/menuJS.ts
+++ b/packages/headless-styles/src/components/Menu/menuJS.ts
@@ -41,7 +41,7 @@ export function UNSAFE_getJSMenuProps(options?: MenuOptions) {
   }
 
   if (!menu) {
-    return baseProps
+    return null
   }
 
   return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #500 

With feature disabled, menu API returns empty props.

## What is the new behavior?

With feature disabled, menu API returns `null`

## Other information
