### PR TITLE
fix(react-utils): prevent default when esc is pressed in useEscToClos…

### DIFF
--- a/packages/react-utils/src/hooks/useEscToClose.ts
+++ b/packages/react-utils/src/hooks/useEscToClose.ts
@@ -5,6 +5,7 @@ export function useEscToClose(onClose: () => void) {
     function handleEscClose(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         event.stopPropagation()
+        event.preventDefault()
         onClose()
       }
     }


### PR DESCRIPTION
…e hook

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #630 

## What is the new behavior?

prevents default handler for `esc` keypress using `useEscToClose` hook, preventing some browsers on some OSes from exiting full screen in addition to the hook's intended behavior.

## Other information
