### PR TITLE
fix(headless-styles): remove multiple select styles from standard select

### DIFF
--- a/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
+++ b/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
@@ -15,9 +15,6 @@ export default {
     paddingInlineEnd: '2.25rem',
     paddingInlineStart: '1rem',
   },
-  selectBase_multiple: {
-    height: 'auto',
-  },
   selectIcon: {
     color: 'var(--ps-text-strong)',
     composes: "inputIcon from '../Input/inputCSS.module.css'",

--- a/packages/headless-styles/src/components/Select/selectCSS.module.css
+++ b/packages/headless-styles/src/components/Select/selectCSS.module.css
@@ -12,10 +12,6 @@
   padding-inline-start: 1rem;
 }
 
-.selectBase[multiple] {
-  height: auto;
-}
-
 .selectIcon {
   color: var(--ps-text-strong);
   composes: inputIcon from '../Input/inputCSS.module.css';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Standard Select CSS includes style for multiple select

## What is the new behavior?

Multi-select style removed from the single-select CSS


## Other information
