### PR TITLE
docs(headless-styles): add optgroup example to Select docs

### DIFF
--- a/website/docs/development/headless-styles/Select.mdx
+++ b/website/docs/development/headless-styles/Select.mdx
@@ -144,6 +144,26 @@ The `select` element does not support the `readonly` attribute. In the case wher
 </select>
 ```
 
+### Grouped options
+
+The `optgroup` element can be used to group and label related options when more organization is needed.
+
+```html
+<select>
+  <optgroup label="Fruits">
+    <option>Apricot</option>
+    <option>Banana</option>
+    <option>Cantaloupe</option>
+  </optgroup>
+
+  <optgroup label="Vegetables">
+    <option>Artichoke</option>
+    <option>Brussels Sprouts</option>
+    <option>Cabbage</option>
+  </optgroup>
+</select>
+```
+
 ## Accessibility and messages
 
 When displaying [Error Messages](./FormControl.mdx#error-messasge) or [Help Text](./FormControl.mdx#help-text) it is required to pass the `options.id` value to the `SelectOptions.describedBy` field. This will add an [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute to the `select` which establishes a relationship between the `select` and message you are displaying.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #693 

Section about `optgroup` missing from Select docs

## What is the new behavior?

Adds section about using `optgroup` to organize Select options

## Other information
