### PR TITLE
docs(react-utils): add docs page for roving tab index hook

### DIFF
--- a/website/docs/development/react-utils/use-roving-tabindex.mdx
+++ b/website/docs/development/react-utils/use-roving-tabindex.mdx
@@ -58,3 +58,7 @@ export default function MenuItem(props) {
   )
 }
 ```
+
+## User experience
+
+By setting the tabindex to 0 for only the currently focused item (selected using arrow keys), the roving tabindex pattern gives keyboard users the option to move past a menu [widget](https://w3c.github.io/aria/#dfn-widget) without needing to `tab` through every item within it (which can be many).

--- a/website/docs/development/react-utils/use-roving-tabindex.mdx
+++ b/website/docs/development/react-utils/use-roving-tabindex.mdx
@@ -1,0 +1,60 @@
+---
+tags: [Development, Packages, React, React utils, useRovingTabIndex, hooks]
+title: useRovingTabIndex
+---
+
+import CodeBlock from '@theme/CodeBlock'
+import ViewSourceLink from '@site/src/components/ViewSourceLink/ViewSourceLink'
+
+A custom hook for controlling the tabIndex prop when using a [Roving Tabindex](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets#technique_1_roving_tabindex) strategy.
+
+<ViewSourceLink
+  icon="github"
+  href="https://github.com/pluralsight/tva/blob/main/packages/react-utils/src/hooks/useRovingTabIndex.ts"
+>
+  View source
+</ViewSourceLink>
+
+## Import
+
+```javascript
+import { useRovingTabIndex } from '@pluralsight/react-utils'
+```
+
+## Basic usage
+
+The `useRovingTabIndex` hook takes no arguments.
+
+```jsx
+const { onBlur, onFocus, tabIndex } = useRovingTabIndex()
+```
+
+## Return value
+
+The `useRovingTabIndex` hook returns a `tabIndex` prop, along with `onFocus` and `onBlur` handlers to manage the tabIndex.
+
+| Name     | Type                          | Description                                |
+| -------- | ----------------------------- | ------------------------------------------ |
+| onBlur   | `(event: FocusEvent) => void` | Blur event callback for managing tabindex  |
+| onFocus  | `(event: FocusEvent) => void` | Focus event callback for managing tabindex |
+| tabIndex | `number`                      | Initial tabindex value                     |
+
+## Example usage in component
+
+Here is an example of how you might use this hook in a MenuItem component alongside the [Menu](../headless-styles/Menu.mdx) Headless-styles helper.
+
+```jsx
+const menuStyles = getMenuProps()
+
+export default function MenuItem(props) {
+  const rovingTabIndexProps = useRovingTabIndex()
+
+  return (
+    <li {...menuStyles.menuListItem}>
+      <button {...menuStyles.menuItem} {...rovingTabIndexProps}>
+        {props.children}
+      </button>
+    </li>
+  )
+}
+```

--- a/website/docs/development/react-utils/use-roving-tabindex.mdx
+++ b/website/docs/development/react-utils/use-roving-tabindex.mdx
@@ -59,6 +59,5 @@ export default function MenuItem(props) {
 }
 ```
 
-## User experience
 
 By setting the tabindex to 0 for only the currently focused item (selected using arrow keys), the roving tabindex pattern gives keyboard users the option to move past a menu [widget](https://w3c.github.io/aria/#dfn-widget) without needing to `tab` through every item within it (which can be many).

--- a/website/docs/development/react-utils/use-roving-tabindex.mdx
+++ b/website/docs/development/react-utils/use-roving-tabindex.mdx
@@ -60,4 +60,4 @@ export default function MenuItem(props) {
 ```
 
 
-By setting the tabindex to 0 for only the currently focused item (selected using arrow keys), the roving tabindex pattern gives keyboard users the option to move past a menu [widget](https://w3c.github.io/aria/#dfn-widget) without needing to `tab` through every item within it (which can be many).
+When used in this example, the `useRovingTabIndex` hook automatically sets the `tabIndex` to `0` for only the currently focused item (selected using arrow keys), this gives keyboard users the option to move past a menu element without needing to `tab` through every item within it (which can be many).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Contributes to #604

## What is the new behavior?
Adds documentation for `useRovingTabIndex` hook

## Other information
