### PR TITLE
feat(hs): use TS to generate declaration file for styles

### DIFF
--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -16,13 +16,13 @@
     "./styles": {
       "import": "./npm/styles.browser.js",
       "require": "./npm/styles.node.js",
-      "types": "./npm/browser/styles.development.js"
+      "types": "./npm/types/generatedStyles.d.ts"
     }
   },
   "typesVersions": {
     "*": {
       "styles": [
-        "npm/browser/styles.development.js"
+        "npm/types/generatedStyles.d.ts"
       ],
       "types": [
         "npm/types/types.d.ts"
@@ -37,16 +37,18 @@
     "sandbox"
   ],
   "scripts": {
-    "build": "yarn clean && yarn bundle && yarn clean:allUnused",
+    "build": "yarn clean && yarn compile:styleTypes && yarn bundle && yarn clean:allUnused",
     "bundle": "rollup --config rollup.config.mjs",
     "clean": "yarn clean:bundles && yarn clean:types",
     "clean:bundles": "rm -rf ./npm/browser && rm -rf ./npm/node",
     "clean:types": "rm -rf ./npm/types",
     "clean:allUnused": "yarn clean:unusedFiles && yarn clean:unusedDirs",
     "clean:unusedFiles": "rm -rf npm/types/index.js",
-    "clean:unusedDirs": "yarn clean:unusedDirs:hs && yarn clean:unusedDirs:shared",
+    "clean:unusedDirs": "yarn clean:unusedDirs:hs && yarn clean:unusedDirs:shared && yarn clean:unusedDirs:components",
+    "clean:unusedDirs:components": "rm -rf npm/types/components",
     "clean:unusedDirs:hs": "rm -rf npm/types/headless-styles",
     "clean:unusedDirs:shared": "rm -rf npm/types/shared",
+    "compile:styleTypes": "tsc --project styles.tsconfig.json",
     "lint:ts": "tsc --project tsconfig.json --noEmit",
     "test": "echo \"'yarn test' should be run from root directory.\" && exit 1"
   },

--- a/packages/headless-styles/rollup.config.mjs
+++ b/packages/headless-styles/rollup.config.mjs
@@ -183,6 +183,14 @@ export default [
     },
   },
   {
+    input: './npm/types/generatedStyles.d.ts',
+    plugins: [dts()],
+    output: {
+      file: 'npm/types/generatedStyles.d.ts',
+      format: formats.es.module,
+    },
+  },
+  {
     input: './npm/types/headless-styles/src/types.d.ts',
     plugins: [dts()],
     output: {

--- a/packages/headless-styles/styles.tsconfig.json
+++ b/packages/headless-styles/styles.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/generatedStyles.ts"],
+  "exclude": ["sandbox", "npm", "tests"],
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "npm/types"
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes #740 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
TS still unhappy with package settings and Rollup is not producing a proper declaration file specifically for the generatedStyles for some reason. However, using the OG TS config works. 🤷‍♀️ 

Rollup still works for all the other files (🤷‍♀️ ) and is faster than reverting everything back to use OG TS config.

## Other information
