### PR TITLE
Narrow types for `createJSProps` and `createCSSObj` return values

### DIFF
--- a/packages/headless-styles/src/utils/helpers.ts
+++ b/packages/headless-styles/src/utils/helpers.ts
@@ -76,7 +76,10 @@ export function createSvelteObj(classname = '') {
   return { class: classname }
 }
 
-export function createCSSObj(className: string, additionalProps?: StyleProps) {
+export function createCSSObj<AdditionalProps extends StyleProps>(
+  className: string,
+  additionalProps?: AdditionalProps
+) {
   return {
     className,
     ...additionalProps,
@@ -91,11 +94,10 @@ export function createClassProp(tech: Tech, classes: ClassOptions) {
   return createCSSObj(classes.defaultClass)
 }
 
-export function createJSProps(
-  cssProps: string,
-  styles: StyleProps,
-  additionalProps?: StyleProps
-): StyleObject {
+export function createJSProps<
+  Styles extends StyleProps,
+  AdditionalProps extends StyleProps
+>(cssProps: string, styles: Styles, additionalProps?: AdditionalProps) {
   return {
     cssProps,
     styles,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [x] Other... Please describe: Typescript changes

## What is the current behavior?

In testing out headless styles, I found it difficult to know what styles were available to reference, because the `styles` entry on all of the `getJS*Props` functions is typed as `Record<string, unknown>`.

## What is the new behavior?

If these changes are accepted, it should improve type definitions on `getJS*Props` so that rather than just having all `styles` entries be `Record<string, unknown>`, it would use the actual values given and infer the types and show what selectors are actually used.