### PR TITLE
refactor(headless-styles): refactor createJSProps to take a single arg

### DIFF
--- a/packages/headless-styles/src/components/Admonition/admonitionJS.ts
+++ b/packages/headless-styles/src/components/Admonition/admonitionJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createAdmonitionProps,
   getAdmonitionClasses,
@@ -45,31 +45,25 @@ export function getJSAdmonitionProps(options?: AdmonitionOptions) {
     ...props,
     description: {
       ...props.description,
-      ...createJSProps(transformStyles(descStyles), descStyles),
+      ...createJSProps(descStyles),
     },
     iconWrapper: {
       ...props.iconWrapper,
-      ...createJSProps(transformStyles(iconWrapperStyles), iconWrapperStyles),
+      ...createJSProps(iconWrapperStyles),
     },
     textContainer: {
       ...props.textContainer,
-      ...createJSProps(
-        transformStyles(textContainerStyles),
-        textContainerStyles
-      ),
+      ...createJSProps(textContainerStyles),
     },
     title: {
       ...props.title,
-      ...createJSProps(
-        transformStyles(styles.admonitionTitle),
-        styles.admonitionTitle
-      ),
+      ...createJSProps(styles.admonitionTitle),
     },
     wrapper: {
       a11yProps: {
         ...props.wrapper,
       },
-      ...createJSProps(transformStyles(wrapperStyles), wrapperStyles),
+      ...createJSProps(wrapperStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Avatar/avatarJS.ts
+++ b/packages/headless-styles/src/components/Avatar/avatarJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createAvatarSelectorClasses,
   getDefaultAvatarOptions,
@@ -33,15 +33,15 @@ export function getJSAvatarProps(options?: AvatarOptions) {
     ...props,
     wrapper: {
       a11yProps: props.wrapper,
-      ...createJSProps(transformStyles(avatarStyles), avatarStyles),
+      ...createJSProps(avatarStyles),
     },
     image: {
       a11yProps: props.image,
-      ...createJSProps(transformStyles(imageStyles), imageStyles),
+      ...createJSProps(imageStyles),
     },
     label: {
       a11yProps: props.label,
-      ...createJSProps(transformStyles(labelStyles), labelStyles),
+      ...createJSProps(labelStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Badge/badgeJS.ts
+++ b/packages/headless-styles/src/components/Badge/badgeJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   getDefaultBadgeOptions,
   createBadgeClasses,
@@ -19,7 +19,7 @@ function getIconStyles(options: BadgeOptions) {
   if (canShowIcon(options.size)) {
     return {
       iconWrapper: {
-        ...createJSProps(transformStyles(styles.badgeIcon), styles.badgeIcon),
+        ...createJSProps(styles.badgeIcon),
       },
     }
   }
@@ -47,7 +47,7 @@ export function getJSBadgeProps(options?: BadgeOptions) {
     ...iconProps,
     badge: {
       ...props.badge,
-      ...createJSProps(transformStyles(badgeStyles), badgeStyles),
+      ...createJSProps(badgeStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Button/buttonJS.ts
+++ b/packages/headless-styles/src/components/Button/buttonJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createButtonProps,
   getButtonClasses,
@@ -25,7 +25,7 @@ export function getJSButtonProps(options?: ButtonOptions) {
     ...props,
     button: {
       ...props.button,
-      ...createJSProps(transformStyles(btnStyles), btnStyles),
+      ...createJSProps(btnStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
+++ b/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createCheckboxProps, getDefaultCheckboxOptions } from './shared'
 import styles from './generated/checkboxCSS.module'
 import type { CheckboxOptions } from './types'
@@ -41,22 +41,19 @@ export function getJSCheckboxProps(options?: CheckboxOptions) {
       a11yProps: {
         ...props.input,
       },
-      ...createJSProps(
-        transformStyles(styles.checkboxInput),
-        styles.checkboxInput
-      ),
+      ...createJSProps(styles.checkboxInput),
     },
     checkboxContainer: {
       a11yProps: {
         ...props.checkboxContainer,
       },
-      ...createJSProps(transformStyles(containerStyles), containerStyles),
+      ...createJSProps(containerStyles),
     },
     checkboxControl: {
       a11yProps: {
         ...props.checkboxControl,
       },
-      ...createJSProps(transformStyles(controlStyles), controlStyles),
+      ...createJSProps(controlStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/CircularProgress/circularProgressJS.ts
+++ b/packages/headless-styles/src/components/CircularProgress/circularProgressJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   getA11yCircularProgressProps,
   getBaseCircleProps,
@@ -36,10 +36,10 @@ export function getJSCircularProgressProps(options?: CircularProgressOptions) {
   return {
     containerProps: {
       a11yProps,
-      ...createJSProps(transformStyles(styles.base), styles.base),
+      ...createJSProps(styles.base),
     },
     svgBoxProps: {
-      ...createJSProps(transformStyles(svgBoxStyles), svgBoxStyles),
+      ...createJSProps(svgBoxStyles),
       keyframes: styles.keyframesSpin['@keyframes spin'],
       svgProps: {
         viewBox: VIEWBOX,
@@ -47,7 +47,7 @@ export function getJSCircularProgressProps(options?: CircularProgressOptions) {
     },
     baseCircleProps: {
       svgProps: getBaseCircleProps(tech),
-      ...createJSProps(transformStyles(styles.circle), styles.circle),
+      ...createJSProps(styles.circle),
     },
     nowCircleProps: {
       keyframes: styles.keyframesLoading['@keyframes loading'],
@@ -55,10 +55,10 @@ export function getJSCircularProgressProps(options?: CircularProgressOptions) {
         ...getBaseCircleProps(tech),
         ...getStrokeProps(now, tech),
       },
-      ...createJSProps(transformStyles(nowStyles), nowStyles),
+      ...createJSProps(nowStyles),
     },
     labelProps: {
-      ...createJSProps(transformStyles(styles.text), styles.text),
+      ...createJSProps(styles.text),
       value,
     },
   }

--- a/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/confirmDialogJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createConfirmDialogIconProps,
   createConfirmDialogProps,
@@ -25,17 +25,11 @@ export function getJSConfirmDialogProps(options?: ConfirmDialogOptions) {
     ...iconProps,
     iconWrapper: {
       ...iconProps.iconWrapper,
-      ...createJSProps(
-        transformStyles(styles.confirmDialogTitleIcon),
-        styles.confirmDialogTitleIcon
-      ),
+      ...createJSProps(styles.confirmDialogTitleIcon),
     },
     header: {
       ...props.header,
-      ...createJSProps(
-        transformStyles(styles.confirmDialogHeader),
-        styles.confirmDialogHeader
-      ),
+      ...createJSProps(styles.confirmDialogHeader),
     },
     confirmTitle: {
       a11yProps: {
@@ -49,51 +43,36 @@ export function getJSConfirmDialogProps(options?: ConfirmDialogOptions) {
     },
     backdrop: {
       ...props.backdrop,
-      ...createJSProps(transformStyles(backdropStyles), backdropStyles),
+      ...createJSProps(backdropStyles),
     },
     buttonGroup: {
       ...props.buttonGroup,
-      ...createJSProps(transformStyles(btnGroupStyles), btnGroupStyles),
+      ...createJSProps(btnGroupStyles),
     },
     cancelButton: {
       ...props.cancelButton,
-      ...createJSProps(
-        transformStyles(styles.confirmDialogCancelBtn),
-        styles.confirmDialogCancelBtn
-      ),
+      ...createJSProps(styles.confirmDialogCancelBtn),
     },
     focusGuard: {
       a11yProps: {
         ...props.focusGuard,
       },
-      ...createJSProps(
-        transformStyles(styles.confirmFocusGuard),
-        styles.confirmFocusGuard
-      ),
+      ...createJSProps(styles.confirmFocusGuard),
     },
     section: {
       a11yProps: {
         ...props.section,
       },
       keyframes: {
-        ...createJSProps(
-          transformStyles(styles.keyframesFadeIn),
-          styles.keyframesFadeIn
-        ),
+        ...createJSProps(styles.keyframesFadeIn),
       },
-      ...createJSProps(
-        transformStyles(styles.confirmDialogSection),
-        styles.confirmDialogSection
-      ),
+      ...createJSProps(styles.confirmDialogSection),
     },
     wrapper: {
       a11yProps: {
         ...props.wrapper,
       },
-      ...createJSProps(
-        transformStyles(styles.confirmDialogWrapper),
-        styles.confirmDialogWrapper
-      ),
+      ...createJSProps(styles.confirmDialogWrapper),
     },
   }
 }

--- a/packages/headless-styles/src/components/ErrorMessage/errorMessageJS.ts
+++ b/packages/headless-styles/src/components/ErrorMessage/errorMessageJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createErrorMessageProps,
   getDefaultErrorMessageOptions,
@@ -23,7 +23,7 @@ export function getJSErrorMessageProps(options?: ErrorMessageOptions) {
     ...errorProps,
     message: {
       ...errorProps.message,
-      ...createJSProps(transformStyles(jsStyles), jsStyles),
+      ...createJSProps(jsStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/FieldMessage/fieldMessageJS.ts
+++ b/packages/headless-styles/src/components/FieldMessage/fieldMessageJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createFieldMessageProps,
   getDefaultFieldMessageOptions,
@@ -22,6 +22,6 @@ export function getJSFieldMessageProps(options?: FieldMessageOptions) {
     message: {
       ...props,
     },
-    ...createJSProps(transformStyles(jsStyles), jsStyles),
+    ...createJSProps(jsStyles),
   }
 }

--- a/packages/headless-styles/src/components/FormControl/formControlJS.ts
+++ b/packages/headless-styles/src/components/FormControl/formControlJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { getDefaultFormControlOptions } from './shared'
 import styles from './generated/formControlCSS.module'
 import type { FormControlOptions } from './types'
@@ -21,7 +21,7 @@ export function getJSFormControlProps(options?: FormControlOptions) {
       'data-disabled': fieldOptions.disabled,
     },
     control: {
-      ...createJSProps(transformStyles(jsStyles), jsStyles),
+      ...createJSProps(jsStyles),
     },
     fieldOptions,
   }

--- a/packages/headless-styles/src/components/FormLabel/formLabelJS.ts
+++ b/packages/headless-styles/src/components/FormLabel/formLabelJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { getDefaultFormLabelOptions, getFormValue } from './shared'
 import styles from './generated/formLabelCSS.module'
 import type { FormLabelOptions } from './types'
@@ -15,7 +15,7 @@ export function getJSFormLabelProps(options?: FormLabelOptions) {
       htmlFor: defaultOptions.htmlFor,
     },
     label: {
-      ...createJSProps(transformStyles(formLabelStyles), formLabelStyles),
+      ...createJSProps(formLabelStyles),
     },
     value: label,
   }

--- a/packages/headless-styles/src/components/Grid/gridJS.ts
+++ b/packages/headless-styles/src/components/Grid/gridJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createGridProps,
   createGridItemProps,
@@ -17,7 +17,7 @@ export function getJSGridProps(options?: GridOptions) {
   }
 
   return {
-    ...createJSProps(transformStyles(containerStyles), containerStyles),
+    ...createJSProps(containerStyles),
   }
 }
 
@@ -26,6 +26,6 @@ export function getJSGridItemProps(options?: GridItemOptions) {
   const { style } = createGridItemProps(defaultOptions)
 
   return {
-    ...createJSProps(transformStyles(style), style),
+    ...createJSProps(style),
   }
 }

--- a/packages/headless-styles/src/components/Icon/iconJS.ts
+++ b/packages/headless-styles/src/components/Icon/iconJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createIconSelectorClasses,
   getA11yIconProps,
@@ -34,6 +34,6 @@ export function getJSIconProps(options?: IconOptions) {
 
   return {
     a11yProps: getA11yIconProps(a11y),
-    ...createJSProps(transformStyles(jsStyles), jsStyles),
+    ...createJSProps(jsStyles),
   }
 }

--- a/packages/headless-styles/src/components/IconButton/iconButtonJS.ts
+++ b/packages/headless-styles/src/components/IconButton/iconButtonJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createIconButtonProps,
   getIconButtonClasses,
@@ -26,7 +26,7 @@ export function getJSIconButtonProps(options?: IconButtonOptions) {
     ...props,
     button: {
       ...props.button,
-      ...createJSProps(transformStyles(btnStyles), btnStyles),
+      ...createJSProps(btnStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Input/inputJS.ts
+++ b/packages/headless-styles/src/components/Input/inputJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createInputInvalidIconProps,
   createInputLeadingIconProps,
@@ -54,29 +54,20 @@ export function getJSInputProps(options?: InputOptions) {
       a11yProps: {
         ...leadingIconProps.iconWrapper,
       },
-      ...createJSProps(
-        transformStyles(leadingIconWrapperStyles),
-        leadingIconWrapperStyles
-      ),
+      ...createJSProps(leadingIconWrapperStyles),
     },
     invalidIconWrapper: {
       a11yProps: {
         ...invalidIconProps.invalidIconWrapper,
       },
-      ...createJSProps(
-        transformStyles(invalidIconWrapperStyles),
-        invalidIconWrapperStyles
-      ),
+      ...createJSProps(invalidIconWrapperStyles),
     },
     input: {
       a11yProps: { ...props.input },
-      ...createJSProps(transformStyles(jsStyles), jsStyles),
+      ...createJSProps(jsStyles),
     },
     inputWrapper: {
-      ...createJSProps(
-        transformStyles(styles.inputWrapper),
-        styles.inputWrapper
-      ),
+      ...createJSProps(styles.inputWrapper),
     },
   }
 }

--- a/packages/headless-styles/src/components/Menu/menuJS.ts
+++ b/packages/headless-styles/src/components/Menu/menuJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createMenuProps,
   getDefaultMenuOptions,
@@ -31,16 +31,13 @@ export function getJSMenuProps(options?: MenuOptions) {
     ...baseProps,
     wrapper: {
       ...baseProps.wrapper,
-      ...createJSProps(transformStyles(styles.menuWrapper), styles.menuWrapper),
+      ...createJSProps(styles.menuWrapper),
     },
     menu: {
       ...baseProps.menu,
-      ...createJSProps(transformStyles(jsStyles.menu), jsStyles.menu),
+      ...createJSProps(jsStyles.menu),
       keyframes: {
-        ...createJSProps(
-          transformStyles(styles.keyframesFadeIn),
-          styles.keyframesFadeIn
-        ),
+        ...createJSProps(styles.keyframesFadeIn),
       },
     },
   }
@@ -77,25 +74,19 @@ export function getJSMenuItemProps(options?: MenuItemOptions) {
     ...baseProps,
     divider: {
       ...baseProps.menuListItem,
-      ...createJSProps(transformStyles(styles.menuDivider), styles.menuDivider),
+      ...createJSProps(styles.menuDivider),
     },
     menuListItem: {
       ...baseProps.menuListItem,
-      ...createJSProps(
-        transformStyles(jsStyles.menuListItem),
-        jsStyles.menuListItem
-      ),
+      ...createJSProps(jsStyles.menuListItem),
     },
     menuItem: {
       ...baseProps.menuItem,
-      ...createJSProps(transformStyles(jsStyles.menuItem), jsStyles.menuItem),
+      ...createJSProps(jsStyles.menuItem),
     },
     menuItemText: {
       ...baseProps.menuItemText,
-      ...createJSProps(
-        transformStyles(styles.menuItemText),
-        styles.menuItemText
-      ),
+      ...createJSProps(styles.menuItemText),
     },
   }
 }

--- a/packages/headless-styles/src/components/Modal/modalJS.ts
+++ b/packages/headless-styles/src/components/Modal/modalJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createModalProps, getDefaultModalOptions } from './shared'
 import styles from '../ConfirmDialog/generated/confirmDialogCSS.module'
 import modalStyles from './generated/modalCSS.module'
@@ -28,66 +28,42 @@ export function getJSModalProps(options?: ModalOptions) {
       a11yProps: {
         ...props.modalHeading,
       },
-      ...createJSProps(
-        transformStyles(combinedStyles.heading),
-        combinedStyles.heading
-      ),
+      ...createJSProps(combinedStyles.heading),
     },
     modalBody: {
       a11yProps: {
         ...props.modalBody,
       },
-      ...createJSProps(
-        transformStyles(modalStyles.modalBody),
-        modalStyles.modalBody
-      ),
+      ...createJSProps(modalStyles.modalBody),
     },
     backdrop: {
       ...props.backdrop,
-      ...createJSProps(
-        transformStyles(combinedStyles.backdrop),
-        combinedStyles.backdrop
-      ),
+      ...createJSProps(combinedStyles.backdrop),
     },
     buttonWrapper: {
       ...props.buttonWrapper,
-      ...createJSProps(
-        transformStyles(modalStyles.modalButtonWrapper),
-        modalStyles.modalButtonWrapper
-      ),
+      ...createJSProps(modalStyles.modalButtonWrapper),
     },
     focusGuard: {
       a11yProps: {
         ...props.focusGuard,
       },
-      ...createJSProps(
-        transformStyles(styles.confirmFocusGuard),
-        styles.confirmFocusGuard
-      ),
+      ...createJSProps(styles.confirmFocusGuard),
     },
     section: {
       a11yProps: {
         ...props.section,
       },
       keyframes: {
-        ...createJSProps(
-          transformStyles(styles.keyframesFadeIn),
-          styles.keyframesFadeIn
-        ),
+        ...createJSProps(styles.keyframesFadeIn),
       },
-      ...createJSProps(
-        transformStyles(combinedStyles.section),
-        combinedStyles.section
-      ),
+      ...createJSProps(combinedStyles.section),
     },
     wrapper: {
       a11yProps: {
         ...props.wrapper,
       },
-      ...createJSProps(
-        transformStyles(styles.confirmDialogWrapper),
-        styles.confirmDialogWrapper
-      ),
+      ...createJSProps(styles.confirmDialogWrapper),
     },
   }
 }

--- a/packages/headless-styles/src/components/Pagination/paginationJS.ts
+++ b/packages/headless-styles/src/components/Pagination/paginationJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import btnStyles from '../Button/generated/buttonCSS.module'
 import { createPaginationProps, getDefaultPaginationOptions } from './shared'
 import styles from './generated/paginationCSS.module'
@@ -35,19 +35,19 @@ export function getJSPaginationProps(options?: PaginationOptions) {
     ...props,
     container: {
       ...props.container,
-      ...createJSProps(transformStyles(containerStyles), containerStyles),
+      ...createJSProps(containerStyles),
     },
     newer: {
       ...props.newer,
-      ...createJSProps(transformStyles(newerStyles), newerStyles),
+      ...createJSProps(newerStyles),
     },
     older: {
       ...props.older,
-      ...createJSProps(transformStyles(olderStyles), olderStyles),
+      ...createJSProps(olderStyles),
     },
     text: {
       ...props.text,
-      ...createJSProps(transformStyles(textStyles), textStyles),
+      ...createJSProps(textStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Popover/popoverJS.ts
+++ b/packages/headless-styles/src/components/Popover/popoverJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { getTooltipPositionStyles } from '../Tooltip/tooltipJS'
 import tooltipStyles from '../Tooltip/generated/tooltipCSS.module'
 import { createPopoverProps, getDefaultPopoverOptions } from './shared'
@@ -54,37 +54,31 @@ export function getJSPopoverProps(options?: PopoverOptions) {
     ...baseProps,
     wrapper: {
       ...baseProps.wrapper,
-      ...createJSProps(transformStyles(jsStyles.wrapper), jsStyles.wrapper),
+      ...createJSProps(jsStyles.wrapper),
     },
     trigger: {
       ...baseProps.trigger,
-      ...createJSProps(transformStyles(jsStyles.trigger), jsStyles.trigger),
+      ...createJSProps(jsStyles.trigger),
     },
     popover: {
       ...baseProps.popover,
-      keyframes: createJSProps(
-        transformStyles(tooltipStyles.keyframesFadeIn),
-        tooltipStyles.keyframesFadeIn
-      ),
-      ...createJSProps(transformStyles(jsStyles.popover), jsStyles.popover),
+      keyframes: createJSProps(tooltipStyles.keyframesFadeIn),
+      ...createJSProps(jsStyles.popover),
     },
     content: {
       ...baseProps.content,
-      ...createJSProps(transformStyles(jsStyles.content), jsStyles.content),
+      ...createJSProps(jsStyles.content),
     },
     header: {
       ...baseProps.header,
-      ...createJSProps(transformStyles(jsStyles.header), jsStyles.header),
+      ...createJSProps(jsStyles.header),
     },
     body: {
       ...baseProps.body,
     },
     closeButtonWrapper: {
       ...baseProps.closeButtonWrapper,
-      ...createJSProps(
-        transformStyles(jsStyles.closeButtonWrapper),
-        jsStyles.closeButtonWrapper
-      ),
+      ...createJSProps(jsStyles.closeButtonWrapper),
     },
   }
 }

--- a/packages/headless-styles/src/components/Progress/progressJS.ts
+++ b/packages/headless-styles/src/components/Progress/progressJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { getA11yProgressProps, getDefaultProgressOptions } from './shared'
 import styles from './generated/progressCSS.module'
 import type { ProgressOptions } from './types'
@@ -65,8 +65,8 @@ export function getJSProgressProps(options?: ProgressOptions) {
   return {
     bar: {
       a11yProps,
-      ...createJSProps(transformStyles(barStyles), barStyles),
+      ...createJSProps(barStyles),
     },
-    wrapper: createJSProps(transformStyles(wrapperStyles), wrapperStyles),
+    wrapper: createJSProps(wrapperStyles),
   }
 }

--- a/packages/headless-styles/src/components/Radio/radioJS.ts
+++ b/packages/headless-styles/src/components/Radio/radioJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createCheckboxFieldProps } from '../sharedDefaultOptions'
 import { getDefaultRadioOptions } from './shared'
 import styles from './generated/radioCSS.module'
@@ -45,19 +45,19 @@ export function getJSRadioProps(options?: RadioOptions) {
         ...props.input,
         type: 'radio',
       },
-      ...createJSProps(transformStyles(styles.radioInput), styles.radioInput),
+      ...createJSProps(styles.radioInput),
     },
     radioContainer: {
       a11yProps: {
         ...props.container,
       },
-      ...createJSProps(transformStyles(containerStyles), containerStyles),
+      ...createJSProps(containerStyles),
     },
     radioControl: {
       a11yProps: {
         ...props.control,
       },
-      ...createJSProps(transformStyles(controlStyles), controlStyles),
+      ...createJSProps(controlStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Select/selectJS.ts
+++ b/packages/headless-styles/src/components/Select/selectJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createSelectProps, getDefaultSelectOptions } from './shared'
 import styles from './generated/selectCSS.module'
 import inputStyles from '../Input/generated/InputCSS.module'
@@ -31,23 +31,17 @@ export function getJSSelectProps(options?: SelectOptions) {
   return {
     ...props,
     fieldWrapper: {
-      ...createJSProps(
-        transformStyles(styles.selectFieldWrapper),
-        styles.selectFieldWrapper
-      ),
+      ...createJSProps(styles.selectFieldWrapper),
     },
     iconWrapper: {
-      ...createJSProps(transformStyles(iconWrapperStyles), iconWrapperStyles),
+      ...createJSProps(iconWrapperStyles),
     },
     select: {
       a11yProps: { ...props.select },
-      ...createJSProps(transformStyles(jsStyles), jsStyles),
+      ...createJSProps(jsStyles),
     },
     selectWrapper: {
-      ...createJSProps(
-        transformStyles(inputStyles.inputWrapper),
-        inputStyles.inputWrapper
-      ),
+      ...createJSProps(inputStyles.inputWrapper),
     },
   }
 }

--- a/packages/headless-styles/src/components/Skeleton/skeletonJS.ts
+++ b/packages/headless-styles/src/components/Skeleton/skeletonJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { getDefaultSkeletonOptions } from './shared'
 import styles from './generated/skeletonCSS.module'
 import type { SkeletonOptions } from './types'
@@ -33,5 +33,5 @@ export function getJSSkeletonProps(options?: SkeletonOptions) {
     },
   }
 
-  return { ...createJSProps(transformStyles(jsStyles), jsStyles), keyframes }
+  return { ...createJSProps(jsStyles), keyframes }
 }

--- a/packages/headless-styles/src/components/Switch/switchJS.ts
+++ b/packages/headless-styles/src/components/Switch/switchJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   getA11yProps,
   getDefaultSwitchOptions,
@@ -58,24 +58,21 @@ export function getJSSwitchProps(options?: SwitchOptions) {
       a11yProps: {
         ...inputProps,
       },
-      ...createJSProps(transformStyles(styles.input), styles.input),
+      ...createJSProps(styles.input),
     },
-    switchContainer: createJSProps(
-      transformStyles(styles.container),
-      styles.container
-    ),
+    switchContainer: createJSProps(styles.container),
     switchTrack: {
       a11yProps: {
         ...hidden,
         ...dataProps,
       },
-      ...createJSProps(transformStyles(trackStyles), trackStyles),
+      ...createJSProps(trackStyles),
     },
     switchThumb: {
       a11yProps: {
         ...dataProps,
       },
-      ...createJSProps(transformStyles(thumbStyles), thumbStyles),
+      ...createJSProps(thumbStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/Tab/tabJS.ts
+++ b/packages/headless-styles/src/components/Tab/tabJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createTabProps, getDefaultTabOptions, getTabClasses } from './shared'
 import styles from './generated/tabCSS.module'
 import type { TabOptions } from './types'
@@ -45,19 +45,19 @@ export function getJSTabProps(options?: TabOptions) {
     ...baseProps,
     wrapper: {
       ...baseProps.wrapper,
-      ...createJSProps(transformStyles(jsStyles.wrapper), jsStyles.wrapper),
+      ...createJSProps(jsStyles.wrapper),
     },
     tabList: {
       ...baseProps.tabList,
-      ...createJSProps(transformStyles(jsStyles.tabList), jsStyles.tabList),
+      ...createJSProps(jsStyles.tabList),
     },
     tab: {
       ...baseProps.tab,
-      ...createJSProps(transformStyles(jsStyles.tab), jsStyles.tab),
+      ...createJSProps(jsStyles.tab),
     },
     tabPanel: {
       ...baseProps.tabPanel,
-      ...createJSProps(transformStyles(jsStyles.tabPanel), jsStyles.tabPanel),
+      ...createJSProps(jsStyles.tabPanel),
     },
   }
 }

--- a/packages/headless-styles/src/components/Table/tableJS.ts
+++ b/packages/headless-styles/src/components/Table/tableJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createTableProps } from './shared'
 import styles from './generated/tableCSS.module'
 
@@ -13,25 +13,25 @@ export function getJSTableProps() {
     ...props,
     table: {
       ...props.table,
-      ...createJSProps(transformStyles(styles.table), styles.table),
+      ...createJSProps(styles.table),
     },
     caption: {
       ...props.caption,
-      ...createJSProps(transformStyles(styles.caption), styles.caption),
+      ...createJSProps(styles.caption),
     },
     headCell: {
       a11yProps: {
         ...props.headCell,
       },
-      ...createJSProps(transformStyles(styles.headCell), styles.headCell),
+      ...createJSProps(styles.headCell),
     },
     bodyCell: {
       ...props.bodyCell,
-      ...createJSProps(transformStyles(bodyCellStyles), bodyCellStyles),
+      ...createJSProps(bodyCellStyles),
     },
     row: {
       ...props.row,
-      ...createJSProps(transformStyles(styles.tableRow), styles.tableRow),
+      ...createJSProps(styles.tableRow),
     },
   }
 }

--- a/packages/headless-styles/src/components/Tag/tagJS.ts
+++ b/packages/headless-styles/src/components/Tag/tagJS.ts
@@ -1,4 +1,4 @@
-import { transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import {
   createTagSelectorClasses,
   getDefaultTagOptions,
@@ -28,8 +28,7 @@ export function getJSTagProps(options?: TagOptions) {
     ...props,
     tag: {
       ...props.tag,
-      cssProps: transformStyles(JsStyles),
-      styles: JsStyles,
+      ...createJSProps(JsStyles),
     },
   }
 }

--- a/packages/headless-styles/src/components/TextLink/textLinkJS.ts
+++ b/packages/headless-styles/src/components/TextLink/textLinkJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createTextLinkProps, getDefaultTextLinkOptions } from './shared'
 import styles from './generated/textLinkCSS.module'
 import type { TextLinkOptions } from './types'
@@ -12,6 +12,6 @@ export function getJSTextLinkProps(options?: TextLinkOptions) {
 
   return {
     ...props,
-    ...createJSProps(transformStyles(jsStyles), jsStyles),
+    ...createJSProps(jsStyles),
   }
 }

--- a/packages/headless-styles/src/components/Textarea/textareaJS.ts
+++ b/packages/headless-styles/src/components/Textarea/textareaJS.ts
@@ -1,4 +1,4 @@
-import { createJSProps, transformStyles } from '../../utils/helpers'
+import { createJSProps } from '../../utils/helpers'
 import { createTextareaOptions, getDefaultTextareaOptions } from './shared'
 import styles from './generated/textareaCSS.module'
 import type { TextareaOptions } from './types'
@@ -28,6 +28,6 @@ export function getJSTextareaProps(options?: TextareaOptions) {
 
   return {
     a11yProps: { ...textareaProps },
-    ...createJSProps(transformStyles(jsStyles), jsStyles),
+    ...createJSProps(jsStyles),
   }
 }

--- a/packages/headless-styles/src/components/Tooltip/tooltipJS.ts
+++ b/packages/headless-styles/src/components/Tooltip/tooltipJS.ts
@@ -1,8 +1,4 @@
-import {
-  createJSProps,
-  type StyleObject,
-  transformStyles,
-} from '../../utils/helpers'
+import { createJSProps, type StyleObject } from '../../utils/helpers'
 import type { Position } from '../types'
 import { createTooltipProps, getDefaultTooltipOptions } from './shared'
 import styles from './generated/tooltipCSS.module'
@@ -112,28 +108,22 @@ export function getJSTooltipProps(options?: TooltipOptions): StyleObject {
     ...props,
     wrapper: {
       a11yProps: props.wrapper,
-      ...createJSProps(transformStyles(jsStyles.wrapper), jsStyles.wrapper),
+      ...createJSProps(jsStyles.wrapper),
     },
     tooltip: {
       a11yProps: props.tooltip,
       keyframes: {
-        ...createJSProps(
-          transformStyles(styles.keyframesFadeIn),
-          styles.keyframesFadeIn
-        ),
+        ...createJSProps(styles.keyframesFadeIn),
       },
-      ...createJSProps(transformStyles(jsStyles.tooltip), jsStyles.tooltip),
+      ...createJSProps(jsStyles.tooltip),
     },
     tooltipContent: {
       a11yProps: props.tooltipContent,
-      ...createJSProps(
-        transformStyles(jsStyles.tooltipContent),
-        jsStyles.tooltipContent
-      ),
+      ...createJSProps(jsStyles.tooltipContent),
     },
     trigger: {
       a11yProps: props.trigger,
-      ...createJSProps(transformStyles(jsStyles.trigger), jsStyles.trigger),
+      ...createJSProps(jsStyles.trigger),
     },
   }
 }

--- a/packages/headless-styles/src/utils/helpers.ts
+++ b/packages/headless-styles/src/utils/helpers.ts
@@ -130,12 +130,9 @@ export function createClassProp(tech: Tech, classes: ClassOptions) {
   return createCSSObj(classes.defaultClass)
 }
 
-export function createJSProps(
-  cssProps: TemplateStringsArray,
-  styles: GeneratedStyles
-) {
+export function createJSProps(styles: GeneratedStyles) {
   return {
-    cssProps,
+    cssProps: transformStyles(styles),
     styles: styles as unknown as CSSObj,
   }
 }

--- a/packages/headless-styles/tests/utils/helpers.test.ts
+++ b/packages/headless-styles/tests/utils/helpers.test.ts
@@ -35,10 +35,9 @@ describe('helpers', () => {
     const styles = {
       backgroundColor: 'blue',
     }
-    const cssProps = `
-      background-color: blue;
-    ` as unknown as TemplateStringsArray
-    expect(createJSProps(cssProps, styles)).toEqual({
+    const cssProps =
+      `background-color: blue;` as unknown as TemplateStringsArray
+    expect(createJSProps(styles)).toEqual({
       cssProps,
       styles,
     })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

All calls to `createJSProps` were in the form of `createJSProps(transformStyles(styleObject), styleObject)`.

## What is the new behavior?

I refactored it to do the `transformStyles` inside of `createJSProps` to simplify usage.