### PR TITLE
Fix/898 inline badge

### DIFF
--- a/packages/headless-styles/src/components/Badge/badgeCSS.module.css
+++ b/packages/headless-styles/src/components/Badge/badgeCSS.module.css
@@ -1,7 +1,7 @@
 .baseBadge {
   align-items: center;
   border-radius: 4px;
-  display: flex;
+  display: inline-flex;
   font-family: inherit;
   font-variation-settings: 'wght' 500;
   font-weight: 500;

--- a/packages/headless-styles/src/components/Badge/generated/badgeCSS.module.ts
+++ b/packages/headless-styles/src/components/Badge/generated/badgeCSS.module.ts
@@ -7,7 +7,7 @@ export default {
   baseBadge: {
     alignItems: 'center',
     borderRadius: '4px',
-    display: 'flex',
+    display: 'inline-flex',
     fontFamily: 'inherit',
     fontVariationSettings: "'wght' 500",
     fontWeight: '500',

--- a/packages/headless-styles/tests/badge/badgeJS.test.ts
+++ b/packages/headless-styles/tests/badge/badgeJS.test.ts
@@ -7,8 +7,8 @@ import { getJSBadgeProps } from '../../src'
 
 describe('Badge JS', () => {
   test('should allow no props to be passed in', () => {
-    expect(getJSBadgeProps().badge.cssProps).toContain('display: flex;')
-    expect(getJSBadgeProps().badge.styles.display).toEqual('flex')
+    expect(getJSBadgeProps().badge.cssProps).toContain('display: inline-flex;')
+    expect(getJSBadgeProps().badge.styles.display).toEqual('inline-flex')
   })
 
   test('should accept a default sentiment type', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #898 

## What is the new behavior?
Changes `flex` to `inline-flex` so badge will be inline by default

## Other information
