### PR TITLE
fix: move input wrapper around just the input and icons

### DIFF
--- a/packages/headless-styles/sandbox/src/components/Input.jsx
+++ b/packages/headless-styles/sandbox/src/components/Input.jsx
@@ -43,7 +43,7 @@ function InputField(props) {
       <div {...inputProps.inputWrapper}>
         {inputProps.iconOptions && (
           <span {...inputProps.iconWrapper}>
-            <CalendarIcon {...getIconProps(inputProps.iconconOptions)} />
+            <CalendarIcon {...getIconProps(inputProps.iconOptions)} />
           </span>
         )}
         {onChange ? (

--- a/packages/headless-styles/sandbox/src/components/Input.jsx
+++ b/packages/headless-styles/sandbox/src/components/Input.jsx
@@ -38,18 +38,27 @@ function InputField(props) {
   const { value, ...input } = inputProps.input
 
   return (
-    <div {...inputProps.inputWrapper} style={{ marginBottom: '1rem' }}>
+    <div style={{ width: '100%', marginBottom: '1rem' }}>
       <label {...labelProps}>{labelProps.value}</label>
-      {inputProps.iconOptions && (
-        <span {...inputProps.iconWrapper}>
-          <CalendarIcon {...getIconProps(inputProps.iconconOptions)} />
-        </span>
-      )}
-      {onChange ? (
-        <input {...input} onChange={onChange} value={value} />
-      ) : (
-        <input {...input} defaultValue={props.defaultValue} />
-      )}
+      <div {...inputProps.inputWrapper}>
+        {inputProps.iconOptions && (
+          <span {...inputProps.iconWrapper}>
+            <CalendarIcon {...getIconProps(inputProps.iconconOptions)} />
+          </span>
+        )}
+        {onChange ? (
+          <input {...input} onChange={onChange} value={value} />
+        ) : (
+          <input {...input} defaultValue={props.defaultValue} />
+        )}
+        {fieldOptions.invalid && (
+          <span {...inputProps.invalidIconWrapper}>
+            <WarningTriangleFilledIcon
+              {...getIconProps(inputProps.invalidIconOptions)}
+            />
+          </span>
+        )}
+      </div>
       {props.helpText && !fieldOptions.invalid && (
         <small {...fieldMessage}>{helpText}</small>
       )}
@@ -57,13 +66,6 @@ function InputField(props) {
         <div {...error.container}>
           <small {...error.message}>{error.message.value}</small>
         </div>
-      )}
-      {fieldOptions.invalid && (
-        <span {...inputProps.invalidIconWrapper}>
-          <WarningTriangleFilledIcon
-            {...getIconProps(inputProps.invalidIconOptions)}
-          />
-        </span>
       )}
     </div>
   )

--- a/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
@@ -5,6 +5,7 @@
 
 export default {
   inputWrapper: {
+    marginTop: '8px',
     position: 'relative',
     width: '100%',
   },
@@ -20,7 +21,6 @@ export default {
     fontFamily: 'inherit',
     fontSize: '0.875rem',
     height: '2rem',
-    marginTop: '8px',
     minWidth: '0',
     outline: 'transparent solid 2px',
     outlineOffset: '2px',
@@ -54,22 +54,17 @@ export default {
   },
   inputIcon: {
     display: 'inline-block',
+    lineHeight: '0',
     position: 'absolute',
     right: '0.798rem',
-    top: '2.2rem',
+    top: '50%',
+    transform: 'translateY(-50%)',
     zIndex: '50',
   },
   inputLeadingIcon: {
     composes: 'inputIcon',
     left: '0.798rem',
     right: 'initial',
-  },
-  mInputIcon: {
-    composes: 'inputIcon',
-  },
-  lInputIcon: {
-    composes: 'inputIcon',
-    top: '2.7rem',
   },
   iconInput: {
     composes: 'defaultInput',

--- a/packages/headless-styles/src/components/Input/inputCSS.module.css
+++ b/packages/headless-styles/src/components/Input/inputCSS.module.css
@@ -1,4 +1,5 @@
 .inputWrapper {
+  margin-top: 8px;
   position: relative;
   width: 100%;
 }
@@ -15,7 +16,6 @@
   font-family: inherit;
   font-size: 0.875rem;
   height: 2rem;
-  margin-top: 8px;
   min-width: 0;
   outline: transparent solid 2px;
   outline-offset: 2px;
@@ -34,9 +34,11 @@
 
 .inputIcon {
   display: inline-block;
+  line-height: 0;
   position: absolute;
   right: 0.798rem;
-  top: 2.2rem;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 50;
 }
 
@@ -44,17 +46,6 @@
   composes: inputIcon;
   left: 0.798rem;
   right: initial;
-}
-
-/* icon sizes */
-
-.mInputIcon {
-  composes: inputIcon;
-}
-
-.lInputIcon {
-  composes: inputIcon;
-  top: 2.7rem;
 }
 
 /* kind */

--- a/packages/headless-styles/src/components/Input/inputCSS.ts
+++ b/packages/headless-styles/src/components/Input/inputCSS.ts
@@ -13,19 +13,19 @@ const INPUT = 'ps-input'
 
 export function getInputProps(options?: InputOptions) {
   const defaultOptions = getDefaultInputOptions(options)
-  const { baseSizeClass, iconSizeClass, kindClass } =
+  const { baseSizeClass, kindClass } =
     createInputClasses<typeof styles>(defaultOptions)
   const props = createInputProps(defaultOptions)
   const leadingIconProps = createInputLeadingIconProps(defaultOptions, {
     iconWrapper: {
       ...createClassNameProp(
-        `${INPUT}-leading-icon ${styles.inputLeadingIcon} ${styles[iconSizeClass]}`
+        `${INPUT}-leading-icon ${styles.inputLeadingIcon}`
       ),
     },
   })
   const invalidIconProps = createInputInvalidIconProps(defaultOptions, {
     invalidIconWrapper: {
-      ...createClassNameProp(`${INPUT}-icon ${styles[iconSizeClass]}`),
+      ...createClassNameProp(`${INPUT}-icon ${styles.inputIcon}`),
     },
   })
 

--- a/packages/headless-styles/src/components/Input/inputJS.ts
+++ b/packages/headless-styles/src/components/Input/inputJS.ts
@@ -37,7 +37,6 @@ export function getJSInputProps(options?: InputOptions) {
   }
   const invalidIconWrapperStyles = {
     ...styles.inputIcon,
-    ...styles[`${defaultOptions.size}InputIcon`],
     ['&[data-invalid="true"]']: {
       ...styles.inputIcon_data_invalid__true,
     },
@@ -45,7 +44,6 @@ export function getJSInputProps(options?: InputOptions) {
   const leadingIconWrapperStyles = {
     ...styles.inputIcon,
     ...styles.inputLeadingIcon,
-    ...styles[`${defaultOptions.size}InputIcon`],
   }
 
   return {

--- a/packages/headless-styles/src/components/Input/shared.ts
+++ b/packages/headless-styles/src/components/Input/shared.ts
@@ -30,7 +30,6 @@ export function getDefaultInputOptions(options?: InputOptions) {
 interface InputStyleKeys<SM> {
   kindClass: StyleKey<SM>
   baseSizeClass: StyleKey<SM>
-  iconSizeClass: StyleKey<SM>
 }
 
 export function createInputClasses<StyleModule>(
@@ -40,7 +39,6 @@ export function createInputClasses<StyleModule>(
   return {
     kindClass: `${options.kind}Input` as StyleKey<StyleModule>,
     baseSizeClass: `${size}InputBase` as StyleKey<StyleModule>,
-    iconSizeClass: `${size}InputIcon` as StyleKey<StyleModule>,
   }
 }
 

--- a/packages/headless-styles/src/components/Select/chakraSelect.ts
+++ b/packages/headless-styles/src/components/Select/chakraSelect.ts
@@ -50,10 +50,6 @@ export const ChakraSelect = {
         ...inputStyles.lInputBase,
         ...styles.lSelectBase,
       },
-      icon: {
-        ...inputStyles.lInputIcon,
-        ...styles.lSelectIcon,
-      },
     },
   },
   defaultProps: {

--- a/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
+++ b/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
@@ -16,17 +16,9 @@ export default {
     paddingInlineStart: '1rem',
   },
   selectIcon: {
-    color: 'var(--ps-text-strong)',
     composes: "inputIcon from '../Input/inputCSS.module.css'",
+    color: 'var(--ps-text-strong)',
     right: '0.5rem',
-    top: '1rem',
-  },
-  mSelectIcon: {
-    composes: 'selectIcon',
-  },
-  lSelectIcon: {
-    composes: 'selectIcon',
-    top: '1.5rem',
   },
   mSelectBase: {
     composes: "mInputBase from '../Input/inputCSS.module.css'",

--- a/packages/headless-styles/src/components/Select/selectCSS.module.css
+++ b/packages/headless-styles/src/components/Select/selectCSS.module.css
@@ -13,19 +13,9 @@
 }
 
 .selectIcon {
-  color: var(--ps-text-strong);
   composes: inputIcon from '../Input/inputCSS.module.css';
+  color: var(--ps-text-strong);
   right: 0.5rem;
-  top: 1rem;
-}
-
-.mSelectIcon {
-  composes: selectIcon;
-}
-
-.lSelectIcon {
-  composes: selectIcon;
-  top: 1.5rem;
 }
 
 /* sizes */

--- a/packages/headless-styles/src/components/Select/selectCSS.ts
+++ b/packages/headless-styles/src/components/Select/selectCSS.ts
@@ -11,8 +11,7 @@ const SELECT = 'ps-select'
 
 export function getSelectProps(options?: SelectOptions) {
   const { size, ...defaultOptions } = getDefaultSelectOptions(options)
-  const { baseSizeClass, iconSizeClass } =
-    createSelectClasses<typeof styles>(size)
+  const { baseSizeClass } = createSelectClasses<typeof styles>(size)
   const props = createSelectProps(defaultOptions)
 
   return {
@@ -33,7 +32,7 @@ export function getSelectProps(options?: SelectOptions) {
     },
     iconWrapper: {
       ...props.iconWrapper,
-      ...createClassNameProp(`${SELECT}-icon ${styles[iconSizeClass]}`),
+      ...createClassNameProp(`${SELECT}-icon ${styles.selectIcon}`),
     },
   }
 }

--- a/packages/headless-styles/src/components/Select/selectJS.ts
+++ b/packages/headless-styles/src/components/Select/selectJS.ts
@@ -25,7 +25,6 @@ export function getJSSelectProps(options?: SelectOptions) {
   const iconWrapperStyles = {
     ...inputStyles.inputIcon,
     ...styles.selectIcon,
-    ...styles[`${defaultOptions.size}SelectIcon`],
   }
 
   return {

--- a/packages/headless-styles/src/components/Select/shared.ts
+++ b/packages/headless-styles/src/components/Select/shared.ts
@@ -14,7 +14,6 @@ export function getDefaultSelectOptions(options?: SelectOptions) {
 
 interface SelectStyleKeys<SM> {
   baseSizeClass: StyleKey<SM>
-  iconSizeClass: StyleKey<SM>
 }
 
 export function createSelectClasses<StyleModule>(
@@ -22,7 +21,6 @@ export function createSelectClasses<StyleModule>(
 ): SelectStyleKeys<StyleModule> {
   return {
     baseSizeClass: `${size}SelectBase` as StyleKey<StyleModule>,
-    iconSizeClass: `${size}SelectIcon` as StyleKey<StyleModule>,
   }
 }
 

--- a/packages/headless-styles/tests/input/inputCSS.test.ts
+++ b/packages/headless-styles/tests/input/inputCSS.test.ts
@@ -74,7 +74,7 @@ describe('Input CSS', () => {
         'data-invalid': true,
       },
       invalidIconWrapper: {
-        className: `${baseClass}-icon lInputIcon`,
+        className: `${baseClass}-icon inputIcon`,
         'data-invalid': true,
       },
       invalidIconOptions: {

--- a/packages/headless-styles/tests/select/selectCSS.test.ts
+++ b/packages/headless-styles/tests/select/selectCSS.test.ts
@@ -14,7 +14,7 @@ describe('Select CSS', () => {
         className: `${baseClass}-fieldWrapper selectFieldWrapper`,
       },
       iconWrapper: {
-        className: `${baseClass}-icon lSelectIcon`,
+        className: `${baseClass}-icon selectIcon`,
       },
       select: {
         ['aria-invalid']: false,
@@ -49,10 +49,6 @@ describe('Select CSS', () => {
     test('should accept a m size option', () => {
       expect(getSelectProps({ ...options, size: 'm' })).toEqual({
         ...result,
-        iconWrapper: {
-          ...result.iconWrapper,
-          className: `${baseClass}-icon mSelectIcon`,
-        },
         select: {
           ...result.select,
           className: `${baseClass} mSelectBase`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #869 

## What is the new behavior?

Moves `inputWrapper` to contain only the input and icons.  
This fits because the label and messages are technically separate, so containing them should be separate as well.
This also makes Input and Select more consistent

## Other information

Removes the need for icon size classes.
Requires an update to documentation
Consider adding a field wrapper to the Form Control helper
