### PR TITLE
Fix/818 pseudo selector transform

### DIFF
--- a/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
+++ b/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
@@ -4,6 +4,19 @@ import camelize from '../utils/camelize'
 import sanitize from '../utils/sanitize'
 import addProperty from '../utils/addProperty'
 
+function kebabSelectorToCamel(text) {
+  return text.replace(/([:[][\w-]+)/g, (str, group1) => {
+    if (shouldNotConvertToCamel(group1)) {
+      return group1
+    }
+    return camelize(group1)
+  })
+}
+
+function shouldNotConvertToCamel(attr) {
+  return /[:[]?(aria|data)-/.test(attr)
+}
+
 const standard = (rule, result) => {
   const obj = {}
   let retObj = {}
@@ -11,8 +24,9 @@ const standard = (rule, result) => {
     const cssProperty = camelize(declaration.property)
     obj[cssProperty] = declaration.value
   })
-  rule.selectors.forEach((selector) => {
+  rule.selectors.forEach((originalSelector) => {
     let name
+    const selector = kebabSelectorToCamel(originalSelector)
 
     // Check if selector contains a pseudo selector
     const pseudoSelectorIndex = selector.indexOf(':')
@@ -45,7 +59,6 @@ const standard = (rule, result) => {
       const attributeSelector = selector.slice(attributeSelectorIndex)
 
       const attrObj = {}
-      // TODO: convert attr selector to JSX-supported camel-case
       attrObj[`&${attributeSelector}`] = obj
 
       name = sanitize(primarySelector.trim())

--- a/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
+++ b/packages/headless-styles/sandbox/plugins/css-to-ts/convert-rules/standard.js
@@ -16,6 +16,7 @@ const standard = (rule, result) => {
 
     // Check if selector contains a pseudo selector
     const pseudoSelectorIndex = selector.indexOf(':')
+    const attributeSelectorIndex = selector.indexOf('[')
     if (pseudoSelectorIndex !== -1) {
       // Find end of pseudo selector
       let endPseudoSelectorIndex = selector.indexOf(' ', pseudoSelectorIndex)
@@ -38,6 +39,17 @@ const standard = (rule, result) => {
 
       name = sanitize(primarySelector.trim())
       retObj = addProperty(result, name, pseudoObj)
+    } else if (attributeSelectorIndex !== -1 && attributeSelectorIndex > 0) {
+      // Split selector
+      const primarySelector = selector.slice(0, attributeSelectorIndex)
+      const attributeSelector = selector.slice(attributeSelectorIndex)
+
+      const attrObj = {}
+      // TODO: convert attr selector to JSX-supported camel-case
+      attrObj[`&${attributeSelector}`] = obj
+
+      name = sanitize(primarySelector.trim())
+      retObj = addProperty(result, name, attrObj)
     } else {
       name = sanitize(selector.trim())
       retObj = addProperty(result, name, obj)

--- a/packages/headless-styles/src/components/Avatar/generated/avatarCSS.module.ts
+++ b/packages/headless-styles/src/components/Avatar/generated/avatarCSS.module.ts
@@ -21,7 +21,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Button/generated/buttonCSS.module.ts
+++ b/packages/headless-styles/src/components/Button/generated/buttonCSS.module.ts
@@ -36,7 +36,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Button/generated/buttonCSS.module.ts
+++ b/packages/headless-styles/src/components/Button/generated/buttonCSS.module.ts
@@ -28,6 +28,10 @@ export default {
     userSelect: 'none',
     verticalAlign: 'middle',
     whiteSpace: 'nowrap',
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+      opacity: '0.5',
+    },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
@@ -107,9 +111,5 @@ export default {
     height: '3rem',
     paddingInlineEnd: '2.156rem',
     paddingInlineStart: '2.156rem',
-  },
-  btnBase_data_disabled__true: {
-    cursor: 'not-allowed',
-    opacity: '0.5',
   },
 }

--- a/packages/headless-styles/src/components/Checkbox/chakraCheckbox.ts
+++ b/packages/headless-styles/src/components/Checkbox/chakraCheckbox.ts
@@ -6,7 +6,7 @@ export const ChakraCheckbox = {
     container: {
       ...styles.checkboxContainer,
       _disabled: {
-        ...styles.checkboxContainer_data_disabled__true,
+        ...styles.checkboxContainer["&[data-disabled='true']"],
       },
     },
     control: {
@@ -18,17 +18,17 @@ export const ChakraCheckbox = {
         ...styles.checkboxInput['&:focus + .checkboxControl'],
       },
       _checked: {
-        ...styles.checkboxControl_data_checked__true,
+        ...styles.checkboxControl["&[data-checked='true']"],
         color: 'white',
         _hover: {
           ...styles.checkboxControl_data_checked__true['&:hover'],
         },
       },
       _disabled: {
-        ...styles.checkboxControl_data_disabled__true,
+        ...styles.checkboxControl["&[data-disabled='true']"],
       },
       _invalid: {
-        ...styles.checkboxControl_data_invalid__true,
+        ...styles.checkboxControl["&[data-invalid='true']"],
         _hover: {
           ...styles.checkboxControl_data_invalid__true['&:hover'],
         },

--- a/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
+++ b/packages/headless-styles/src/components/Checkbox/checkboxJS.ts
@@ -9,26 +9,11 @@ export function getJSCheckboxProps(options?: CheckboxOptions) {
   const containerStyles = {
     ...styles.checkboxContainer,
     ...styles[defaultOptions.direction as keyof typeof styles],
-    '&[data-disabled="true"]': {
-      ...styles.checkboxContainer_data_disabled__true,
-    },
-    '&[data-readonly="true"]': {
-      ...styles.checkboxContainer_data_readonly__true,
-    },
   }
   const controlStyles = {
     ...styles.checkboxControl,
-    '&[data-checked="true"]': {
-      ...styles.checkboxControl_data_checked__true,
-    },
     '&[data-checked="true"]:hover': {
       ...styles.checkboxControl_data_checked__true['&:hover'],
-    },
-    '&[data-disabled="true"]': {
-      ...styles.checkboxControl_data_disabled__true,
-    },
-    '&[data-invalid="true"]': {
-      ...styles.checkboxControl_data_invalid__true,
     },
     '&[data-invalid="true"]:hover': {
       ...styles.checkboxControl_data_invalid__true['&:hover'],

--- a/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
+++ b/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
@@ -32,7 +32,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .checkboxControl': {
+    '&:focus:not(:focusVisible) + .checkboxControl': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
+++ b/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
@@ -10,6 +10,12 @@ export default {
     display: 'inline-flex',
     position: 'relative',
     verticalAlign: 'top',
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-readonly='true']": {
+      cursor: 'not-allowed',
+    },
   },
   checkboxInput: {
     border: '0',
@@ -54,29 +60,27 @@ export default {
       background: 'var(--ps-background-hover)',
       borderColor: 'var(--ps-background-hover)',
     },
-  },
-  checkboxContainer_data_disabled__true: {
-    cursor: 'not-allowed',
-  },
-  checkboxContainer_data_readonly__true: {
-    cursor: 'not-allowed',
+    "&[data-checked='true']": {
+      background: 'var(--ps-action-background)',
+      borderColor: 'var(--ps-action-background)',
+    },
+    "&[data-disabled='true']": {
+      background: 'var(--ps-background)',
+      borderColor: 'var(--ps-background)',
+    },
+    "&[data-invalid='true']": {
+      background: 'var(--ps-danger-surface)',
+      borderColor: 'var(--ps-danger-surface)',
+      color: 'var(--ps-danger-text)',
+    },
   },
   checkboxControl_data_checked__true: {
-    background: 'var(--ps-action-background)',
-    borderColor: 'var(--ps-action-background)',
     '&:hover': {
       background: 'var(--ps-action-background-hover)',
       borderColor: 'var(--ps-action-background-hover)',
     },
   },
-  checkboxControl_data_disabled__true: {
-    background: 'var(--ps-background)',
-    borderColor: 'var(--ps-background)',
-  },
   checkboxControl_data_invalid__true: {
-    background: 'var(--ps-danger-surface)',
-    borderColor: 'var(--ps-danger-surface)',
-    color: 'var(--ps-danger-text)',
     '&:hover': {
       background: 'var(--ps-danger-surface)',
       borderColor: 'var(--ps-danger-surface)',

--- a/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
@@ -43,7 +43,7 @@ export default {
     textAlign: 'right',
   },
   confirmDialogBtnGroup_button: {
-    '&:first-of-type': {
+    '&:firstOfType': {
       marginRight: '1rem',
     },
   },

--- a/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
+++ b/packages/headless-styles/src/components/ConfirmDialog/generated/confirmDialogCSS.module.ts
@@ -21,8 +21,10 @@ export default {
       '-PsBackdrop': 'rgba(0 0 0 / 65%)',
     },
   },
-  html_data_theme__light: {
-    '-PsBackdrop': 'rgba(255 255 255 / 65%)',
+  html: {
+    "&[data-theme='light']": {
+      '-PsBackdrop': 'rgba(255 255 255 / 65%)',
+    },
   },
   light: {
     '-PsBackdrop': 'rgba(255 255 255 / 65%)',

--- a/packages/headless-styles/src/components/FormControl/generated/formControlCSS.module.ts
+++ b/packages/headless-styles/src/components/FormControl/generated/formControlCSS.module.ts
@@ -3,15 +3,14 @@
 //
 // Manual changes will be lost - proceed with caution!
 
-
 export default {
-  "formControlBase": {
-    "alignItems": "center",
-    "display": "flex",
-    "position": "relative",
-    "width": "100%"
+  formControlBase: {
+    alignItems: 'center',
+    display: 'flex',
+    position: 'relative',
+    width: '100%',
+    "&[data-disabled='true']": {
+      opacity: '0.5',
+    },
   },
-  "formControlBase_data_disabled__true": {
-    "opacity": "0.5"
-  }
 }

--- a/packages/headless-styles/src/components/Input/chakraInput.ts
+++ b/packages/headless-styles/src/components/Input/chakraInput.ts
@@ -14,16 +14,16 @@ const chakraInputStyle = {
       ...styles.defaultInput['&:focus'],
     },
     _disabled: {
-      ...styles.defaultInput_data_disabled__true,
+      ...styles.defaultInput["&[data-disabled='true']"],
       _hover: {
         ...styles.defaultInput_data_disabled__true['&:hover'],
       },
     },
     _invalid: {
-      ...styles.defaultInput_data_invalid__true,
+      ...styles.defaultInput["&[data-invalid='true']"],
     },
     _readOnly: {
-      ...styles.defaultInput_data_readonly__true,
+      ...styles.defaultInput["&[data-readonly='true']"],
       _hover: {
         ...styles.defaultInput_data_readonly__true['&:hover'],
       },

--- a/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
@@ -41,7 +41,7 @@ export default {
       boxShadow: 'none',
       outline: '3px solid var(--ps-action-border-focus)',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
@@ -45,6 +45,16 @@ export default {
       boxShadow: 'none',
       outline: 'none',
     },
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-invalid='true']": {
+      borderColor: 'var(--ps-danger-border)',
+      boxShadow: 'var(--ps-danger-border) 0 0 0 1px',
+    },
+    "&[data-readonly='true']": {
+      cursor: 'not-allowed',
+    },
   },
   '': {
     '&::placeholder': {
@@ -60,6 +70,9 @@ export default {
     top: '50%',
     transform: 'translateY(-50%)',
     zIndex: '50',
+    "&[data-invalid='true']": {
+      color: 'var(--ps-danger-text-weak)',
+    },
   },
   inputLeadingIcon: {
     composes: 'inputIcon',
@@ -79,23 +92,13 @@ export default {
     height: '3rem',
   },
   defaultInput_data_disabled__true: {
-    opacity: '0.7',
-    cursor: 'not-allowed',
     '&:hover': {
       boxShadow: 'none',
     },
-  },
-  defaultInput_data_invalid__true: {
-    borderColor: 'var(--ps-danger-border)',
-    boxShadow: 'var(--ps-danger-border) 0 0 0 1px',
   },
   defaultInput_data_readonly__true: {
-    cursor: 'not-allowed',
     '&:hover': {
       boxShadow: 'none',
     },
-  },
-  inputIcon_data_invalid__true: {
-    color: 'var(--ps-danger-text-weak)',
   },
 }

--- a/packages/headless-styles/src/components/Input/inputJS.ts
+++ b/packages/headless-styles/src/components/Input/inputJS.ts
@@ -19,15 +19,6 @@ export function getJSInputProps(options?: InputOptions) {
     ['&::placeholder']: {
       ...styles['']['&::placeholder'],
     },
-    ['&[data-disabled="true"]']: {
-      ...styles.defaultInput_data_disabled__true,
-    },
-    ['&[data-invalid="true"]']: {
-      ...styles.defaultInput_data_invalid__true,
-    },
-    ['&[data-readonly="true"]']: {
-      ...styles.defaultInput_data_readonly__true,
-    },
     ['&[data-disabled="true"]:hover']: {
       ...styles.defaultInput_data_disabled__true['&:hover'],
     },
@@ -37,9 +28,6 @@ export function getJSInputProps(options?: InputOptions) {
   }
   const invalidIconWrapperStyles = {
     ...styles.inputIcon,
-    ['&[data-invalid="true"]']: {
-      ...styles.inputIcon_data_invalid__true,
-    },
   }
   const leadingIconWrapperStyles = {
     ...styles.inputIcon,

--- a/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
+++ b/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
@@ -41,6 +41,9 @@ export default {
     top: '100%',
     width: '14rem',
     zIndex: '1000',
+    "&[data-expanded='true']": {
+      display: 'block',
+    },
   },
   menuWrapper: {
     position: 'relative',
@@ -115,6 +118,13 @@ export default {
       top: '0',
       zIndex: '1010',
     },
+    "&[aria-expanded='true'] ~ .menu": {
+      display: 'block',
+    },
+    "&[aria-expanded='true']": {
+      background: 'var(--ps-action-background)',
+      color: 'var(--ps-action-text)',
+    },
     '&:active': {
       background: 'var(--ps-action-background)',
       color: 'var(--ps-action-text)',
@@ -141,15 +151,5 @@ export default {
   },
   menuItem___svg: {
     flex: '0 0 auto',
-  },
-  menuItem_aria_expanded__true______menu: {
-    display: 'block',
-  },
-  menu_data_expanded__true: {
-    display: 'block',
-  },
-  menuItem_aria_expanded__true: {
-    background: 'var(--ps-action-background)',
-    color: 'var(--ps-action-text)',
   },
 }

--- a/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
+++ b/packages/headless-styles/src/components/Menu/generated/menuCSS.module.ts
@@ -89,7 +89,7 @@ export default {
     transition: 'background-color 250ms ease-in-out, color 250ms ease-in-out',
     whiteSpace: 'nowrap',
     width: '100%',
-    '&:any-link': {
+    '&:anyLink': {
       appearance: 'none',
       background: 'transparent',
       border: '0',
@@ -137,7 +137,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Menu/menuJS.ts
+++ b/packages/headless-styles/src/components/Menu/menuJS.ts
@@ -22,7 +22,6 @@ export function getJSMenuProps(options?: MenuOptions) {
   const jsStyles = {
     menu: {
       ...styles.menu,
-      '&[data-expanded="true"]': styles.menu_data_expanded__true,
     },
   }
 
@@ -64,7 +63,6 @@ export function getJSMenuItemProps() {
       ...styles.menuItem,
       '& > *': styles.menuItem___all_children,
       '& > svg': styles.menuItem___svg,
-      '&[aria-expanded="true"]': styles.menuItem_aria_expanded__true,
     },
   }
 

--- a/packages/headless-styles/src/components/Pagination/generated/paginationCSS.module.ts
+++ b/packages/headless-styles/src/components/Pagination/generated/paginationCSS.module.ts
@@ -30,7 +30,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
+++ b/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
@@ -79,7 +79,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
+++ b/packages/headless-styles/src/components/Popover/generated/popoverCSS.module.ts
@@ -14,6 +14,9 @@ export default {
     minWidth: '17.5em',
     textAlign: 'start',
     zIndex: '1500',
+    "&[data-expanded='true']": {
+      display: 'inline-block',
+    },
   },
   popoverContent: {
     composes: "tooltipContentBase from '../Tooltip/tooltipCSS.module.css'",
@@ -80,11 +83,8 @@ export default {
       boxShadow: 'none',
       outline: 'none',
     },
-  },
-  popover_data_expanded__true: {
-    display: 'inline-block',
-  },
-  popoverTrigger_aria_expanded__true______data_popover: {
-    display: 'inline-block',
+    "&[aria-expanded='true'] + [data-popover]": {
+      display: 'inline-block',
+    },
   },
 }

--- a/packages/headless-styles/src/components/Radio/chakraRadio.ts
+++ b/packages/headless-styles/src/components/Radio/chakraRadio.ts
@@ -6,7 +6,7 @@ export const ChakraRadio = {
     container: {
       ...styles.radioContainer,
       _disabled: {
-        ...styles.radioContainer_data_disabled__true,
+        ...styles.radioContainer["&[data-disabled='true']"],
       },
     },
     control: {
@@ -18,7 +18,7 @@ export const ChakraRadio = {
         ...styles.radioInput['&:focus + .radioControl'],
       },
       _checked: {
-        ...styles.radioControl_data_checked__true,
+        ...styles.radioControl["&[data-checked='true']"],
         _before: {
           ...styles.radioControl_data_checked__true['&::before'],
         },
@@ -27,10 +27,10 @@ export const ChakraRadio = {
         },
       },
       _disabled: {
-        ...styles.radioControl_data_disabled__true,
+        ...styles.radioContainer["&[data-disabled='true']"],
       },
       _invalid: {
-        ...styles.radioControl_data_invalid__true,
+        ...styles.radioControl["&[data-invalid='true']"],
         _hover: {
           ...styles.radioControl_data_invalid__true['&:hover'],
         },

--- a/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
+++ b/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
@@ -14,6 +14,12 @@ export default {
     display: 'inline-flex',
     marginInlineStart: '1rem',
     verticalAlign: 'top',
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-readonly='true']": {
+      cursor: 'not-allowed',
+    },
   },
   radioInput: {
     border: '0',
@@ -54,16 +60,20 @@ export default {
     '&:hover': {
       background: 'var(--ps-background-hover)',
     },
-  },
-  radioContainer_data_disabled__true: {
-    cursor: 'not-allowed',
-  },
-  radioContainer_data_readonly__true: {
-    cursor: 'not-allowed',
+    "&[data-checked='true']": {
+      background: 'var(--ps-action-background)',
+      borderColor: 'var(--ps-action-background)',
+    },
+    "&[data-disabled='true']": {
+      background: 'var(--ps-background)',
+      borderColor: 'var(--ps-background)',
+    },
+    "&[data-invalid='true']": {
+      background: 'var(--ps-danger-surface)',
+      borderColor: 'var(--ps-danger-surface)',
+    },
   },
   radioControl_data_checked__true: {
-    background: 'var(--ps-action-background)',
-    borderColor: 'var(--ps-action-background)',
     '&:hover': {
       background: 'var(--ps-action-background-hover)',
       borderColor: 'var(--ps-action-background-hover)',
@@ -78,13 +88,7 @@ export default {
       width: '50%',
     },
   },
-  radioControl_data_disabled__true: {
-    background: 'var(--ps-background)',
-    borderColor: 'var(--ps-background)',
-  },
   radioControl_data_invalid__true: {
-    background: 'var(--ps-danger-surface)',
-    borderColor: 'var(--ps-danger-surface)',
     '&:hover': {
       background: 'var(--ps-danger-surface)',
       borderColor: 'var(--ps-danger-surface)',

--- a/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
+++ b/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
@@ -35,7 +35,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .radioControl': {
+    '&:focus:not(:focusVisible) + .radioControl': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Radio/radioJS.ts
+++ b/packages/headless-styles/src/components/Radio/radioJS.ts
@@ -10,29 +10,14 @@ export function getJSRadioProps(options?: RadioOptions) {
   const containerStyles = {
     ...styles.radioContainer,
     ...styles[defaultOptions.direction as keyof typeof styles],
-    '&[data-disabled="true"]': {
-      ...styles.radioContainer_data_disabled__true,
-    },
-    '&[data-readonly="true"]': {
-      ...styles.radioContainer_data_readonly__true,
-    },
   }
   const controlStyles = {
     ...styles.radioControl,
-    '&[data-checked="true"]': {
-      ...styles.radioControl_data_checked__true,
-    },
     '&[data-checked="true"]:hover': {
       ...styles.radioControl_data_checked__true['&:hover'],
     },
     '&[data-checked="true"]::before': {
       ...styles.radioControl_data_checked__true['&::before'],
-    },
-    '&[data-disabled="true"]': {
-      ...styles.radioControl_data_disabled__true,
-    },
-    '&[data-invalid="true"]': {
-      ...styles.radioControl_data_invalid__true,
     },
     '&[data-invalid="true"]:hover': {
       ...styles.radioControl_data_invalid__true['&:hover'],

--- a/packages/headless-styles/src/components/Select/chakraSelect.ts
+++ b/packages/headless-styles/src/components/Select/chakraSelect.ts
@@ -16,13 +16,13 @@ const baseSelectStyles = {
     borderColor: 'none',
   },
   _disabled: {
-    ...inputStyles.defaultInput_data_disabled__true,
+    ...inputStyles.defaultInput["&[data-disabled='true']"],
     _hover: {
       ...inputStyles.defaultInput_data_disabled__true['&:hover'],
     },
   },
   _invalid: {
-    ...inputStyles.defaultInput_data_invalid__true,
+    ...inputStyles.defaultInput["&[data-invalid='true']"],
   },
 }
 

--- a/packages/headless-styles/src/components/Select/selectJS.ts
+++ b/packages/headless-styles/src/components/Select/selectJS.ts
@@ -12,12 +12,6 @@ export function getJSSelectProps(options?: SelectOptions) {
     ...styles.selectBase,
     ...inputStyles[`${defaultOptions.size}InputBase`],
     ...styles[`${defaultOptions.size}SelectBase`],
-    ['&[data-disabled="true"]']: {
-      ...inputStyles.defaultInput_data_disabled__true,
-    },
-    ['&[data-invalid="true"]']: {
-      ...inputStyles.defaultInput_data_invalid__true,
-    },
     ['&[data-disabled="true"]:hover']: {
       ...inputStyles.defaultInput_data_disabled__true['&:hover'],
     },

--- a/packages/headless-styles/src/components/Switch/chakraSwitch.ts
+++ b/packages/headless-styles/src/components/Switch/chakraSwitch.ts
@@ -12,6 +12,8 @@ const baseTrackStyles = {
   width: mTrackWidth,
 }
 
+const checkedAttr = "&[data-checked='true']"
+
 export const ChakraSwitch = {
   baseStyle: {
     container: styles.container,
@@ -20,7 +22,7 @@ export const ChakraSwitch = {
       height: isSizeS('m', THUMB_SIZE),
       width: isSizeS('m', THUMB_SIZE),
       _checked: {
-        ...styles.thumb_data_checked__true,
+        ...styles.thumb[checkedAttr],
         transform: `translateX(calc(${mTrackWidth} - ${mTrackHeight}))`,
       },
     },
@@ -30,19 +32,19 @@ export const ChakraSwitch = {
         ...baseTrackStyles['&:hover'],
       },
       _checked: {
-        ...styles.track_data_checked__true,
+        ...styles.track[checkedAttr],
         _hover: {
           ...styles.track_data_checked__true['&:hover'],
         },
       },
       _disabled: {
-        ...styles.track_data_disabled__true,
+        ...styles.track["&[data-disabled='true']"],
         _hover: {
           ...styles.track_data_disabled__true['&:hover'],
         },
       },
       _invalid: {
-        ...styles.track_data_invalid__true,
+        ...styles.track["&[data-invalid='true']"],
         _hover: {
           ...styles.track_data_invalid__true['&:hover'],
         },
@@ -59,7 +61,7 @@ export const ChakraSwitch = {
         height: isSizeS('s', THUMB_SIZE),
         width: isSizeS('s', THUMB_SIZE),
         _checked: {
-          ...styles.thumb_data_checked__true,
+          ...styles.thumb[checkedAttr],
           transform: `translateX(calc(${sTrackWidth} - ${sTrackHeight}))`,
         },
       },

--- a/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
+++ b/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
@@ -24,7 +24,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible) + .track': {
+    '&:focus:not(:focusVisible) + .track': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
+++ b/packages/headless-styles/src/components/Switch/generated/switchCSS.module.ts
@@ -36,6 +36,10 @@ export default {
     transitionDuration: '200ms',
     transitionProperty: 'transform',
     width: 'var(--ps-thumb-size)',
+    "&[data-checked='true']": {
+      transform:
+        'translateX(calc(var(--ps-track-width) - var(--ps-track-height)))',
+    },
   },
   track: {
     '-PsThumbSize': '1.25rem',
@@ -56,28 +60,30 @@ export default {
     '&:hover': {
       background: 'var(--ps-background-hover)',
     },
-  },
-  thumb_data_checked__true: {
-    transform:
-      'translateX(calc(var(--ps-track-width) - var(--ps-track-height)))',
+    "&[data-checked='true']": {
+      background: 'var(--ps-action-background)',
+    },
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-readonly='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-invalid='true']": {
+      background: 'var(--ps-danger-surface)',
+    },
   },
   track_data_checked__true: {
-    background: 'var(--ps-action-background)',
     '&:hover': {
       background: 'var(--ps-action-background-hover)',
     },
   },
   track_data_disabled__true: {
-    cursor: 'not-allowed',
     '&:hover': {
       background: 'var(--ps-background)',
     },
   },
-  track_data_readonly__true: {
-    cursor: 'not-allowed',
-  },
   track_data_invalid__true: {
-    background: 'var(--ps-danger-surface)',
     '&:hover': {
       background: 'var(--ps-danger-surface)',
     },

--- a/packages/headless-styles/src/components/Switch/switchJS.ts
+++ b/packages/headless-styles/src/components/Switch/switchJS.ts
@@ -22,26 +22,14 @@ export function getJSSwitchProps(options?: SwitchOptions) {
     ...styles[`${size}Track`],
     height: trackHeight,
     width: trackWidth,
-    '&[data-checked="true"]': {
-      ...styles.track_data_checked__true,
-    },
     '&[data-checked="true"]:hover': {
       ...styles.track_data_checked__true['&:hover'],
-    },
-    '&[data-disabled="true"]': {
-      ...styles.track_data_disabled__true,
     },
     '&[data-disabled="true"]:hover': {
       ...styles.track_data_disabled__true['&:hover'],
     },
-    '&[data-invalid="true"]': {
-      ...styles.track_data_invalid__true,
-    },
     '&[data-invalid="true"]:hover': {
       ...styles.track_data_invalid__true['&:hover'],
-    },
-    '&[data-readonly="true"]': {
-      ...styles.track_data_readonly__true,
     },
   }
   const thumbStyles = {

--- a/packages/headless-styles/src/components/Tab/generated/tabCSS.module.ts
+++ b/packages/headless-styles/src/components/Tab/generated/tabCSS.module.ts
@@ -20,7 +20,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -66,7 +66,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },
@@ -99,7 +99,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Tab/generated/tabCSS.module.ts
+++ b/packages/headless-styles/src/components/Tab/generated/tabCSS.module.ts
@@ -59,6 +59,9 @@ export default {
     '&:hover::after': {
       height: '0.25rem',
     },
+    "&[aria-selected='true']": {
+      color: 'var(--ps-action-text-inverse)',
+    },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
@@ -81,7 +84,6 @@ export default {
     },
   },
   tabBase_aria_selected__true: {
-    color: 'var(--ps-action-text-inverse)',
     '&::after': {
       backgroundColor: 'var(--ps-action-border)',
       height: '0.25rem',
@@ -90,6 +92,9 @@ export default {
   tabPanel: {
     borderRadius: '6px',
     width: '100%',
+    "&[aria-hidden='true']": {
+      display: 'none',
+    },
     '&:focus': {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
@@ -98,8 +103,5 @@ export default {
       boxShadow: 'none',
       outline: 'none',
     },
-  },
-  tabPanel_aria_hidden__true: {
-    display: 'none',
   },
 }

--- a/packages/headless-styles/src/components/Tab/tabJS.ts
+++ b/packages/headless-styles/src/components/Tab/tabJS.ts
@@ -35,13 +35,11 @@ export function getJSTabProps(options?: TabOptions) {
     tab: {
       ...styles.tabBase,
       ...styles[sizeClass],
-      "&[aria-selected='true']": styles.tabBase_aria_selected__true,
       "&[aria-selected='true']::after":
         styles.tabBase_aria_selected__true['&::after'],
     },
     tabPanel: {
       ...styles.tabPanel,
-      "&[aria-hidden='true']": styles.tabPanel_aria_hidden__true,
     },
   }
 

--- a/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
+++ b/packages/headless-styles/src/components/Tag/generated/tagCSS.module.ts
@@ -45,7 +45,7 @@ export default {
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       color: 'var(--ps-action-navigation-visited)',
       outline: 'none',

--- a/packages/headless-styles/src/components/TextLink/generated/textLinkCSS.module.ts
+++ b/packages/headless-styles/src/components/TextLink/generated/textLinkCSS.module.ts
@@ -28,7 +28,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Textarea/chakraTextarea.ts
+++ b/packages/headless-styles/src/components/Textarea/chakraTextarea.ts
@@ -15,16 +15,16 @@ const chakraTextareaStyle = {
     borderColor: 'none',
   },
   _disabled: {
-    ...styles.textareaBase_data_disabled__true,
+    ...styles.textareaBase["&[data-disabled='true']"],
     _hover: {
       ...styles.textareaBase_data_disabled__true['&:hover'],
     },
   },
   _invalid: {
-    ...styles.textareaBase_data_invalid__true,
+    ...styles.textareaBase["&[data-invalid='true']"],
   },
   _readOnly: {
-    ...styles.textareaBase_data_readonly__true,
+    ...styles.textareaBase["&[data-readonly='true']"],
     _hover: {
       ...styles.textareaBase_data_readonly__true['&:hover'],
     },

--- a/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
+++ b/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
@@ -41,7 +41,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },

--- a/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
+++ b/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
@@ -45,6 +45,16 @@ export default {
       boxShadow: 'none',
       outline: 'none',
     },
+    "&[data-disabled='true']": {
+      cursor: 'not-allowed',
+    },
+    "&[data-invalid='true']": {
+      borderColor: 'var(--ps-danger-border)',
+      boxShadow: 'var(--ps-danger-border) 0 0 0 2px',
+    },
+    "&[data-readonly='true']": {
+      cursor: 'not-allowed',
+    },
   },
   initialTextarea: {
     composes: 'textareaBase',
@@ -62,18 +72,11 @@ export default {
     resize: 'vertical',
   },
   textareaBase_data_disabled__true: {
-    opacity: '0.5',
-    cursor: 'not-allowed',
     '&:hover': {
       boxShadow: 'none',
     },
   },
-  textareaBase_data_invalid__true: {
-    borderColor: 'var(--ps-danger-border)',
-    boxShadow: 'var(--ps-danger-border) 0 0 0 2px',
-  },
   textareaBase_data_readonly__true: {
-    cursor: 'not-allowed',
     '&:hover': {
       boxShadow: 'none',
     },

--- a/packages/headless-styles/src/components/Textarea/textareaJS.ts
+++ b/packages/headless-styles/src/components/Textarea/textareaJS.ts
@@ -9,15 +9,6 @@ export function getJSTextareaProps(options?: TextareaOptions) {
   const jsStyles = {
     ...styles.textareaBase,
     ...styles[`${defaultOptions.resize}Textarea`],
-    ['&[data-disabled="true"]']: {
-      ...styles.textareaBase_data_disabled__true,
-    },
-    ['&[data-invalid="true"]']: {
-      ...styles.textareaBase_data_invalid__true,
-    },
-    ['&[data-readonly="true"]']: {
-      ...styles.textareaBase_data_readonly__true,
-    },
     ['&[data-disabled="true"]:hover']: {
       ...styles.textareaBase_data_disabled__true['&:hover'],
     },

--- a/packages/headless-styles/src/components/Tooltip/generated/tooltipCSS.module.ts
+++ b/packages/headless-styles/src/components/Tooltip/generated/tooltipCSS.module.ts
@@ -20,7 +20,7 @@ export default {
     "&:hover > [data-tooltip]:not([data-disabled='true'])": {
       display: 'inline-block',
     },
-    "&:focus-within > [data-tooltip]:not([data-disabled='true'])": {
+    "&:focusWithin > [data-tooltip]:not([data-disabled='true'])": {
       display: 'inline-block',
     },
   },
@@ -77,7 +77,7 @@ export default {
       outline: '3px solid var(--ps-action-border-focus)',
       outlineOffset: '2px',
     },
-    '&:focus:not(:focus-visible)': {
+    '&:focus:not(:focusVisible)': {
       boxShadow: 'none',
       outline: 'none',
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #818 

## What is the new behavior?
Converts hyphenated pseudo- and attribute selectors in generated CSS-to-JS objects to camel case for React/JSX based frameworks

## Other information
Nests 1st-level attribute selectors using '&', removing the need to manually add these in JS 
