### PR TITLE
Feat/868 class merge single

### DIFF
--- a/packages/headless-styles/src/components/Badge/badgeCSS.ts
+++ b/packages/headless-styles/src/components/Badge/badgeCSS.ts
@@ -34,7 +34,8 @@ export function getBadgeProps(options?: BadgeOptions) {
     badge: {
       ...props.badge,
       ...createClassNameProp(
-        `${BADGE} ${styles[sentimentClass]} ${styles[sizeClass]} ${styles[usageClass]}`
+        `${BADGE} ${styles[sentimentClass]} ${styles[sizeClass]} ${styles[usageClass]}`,
+        defaultOptions.className
       ),
     },
   }

--- a/packages/headless-styles/src/components/Badge/shared.ts
+++ b/packages/headless-styles/src/components/Badge/shared.ts
@@ -1,5 +1,5 @@
 import type { StyleKey } from '../types'
-import type { BadgeOptions, BadgeSize, DefaultBadgeOptions } from './types'
+import type { BadgeOptions, BadgeSize } from './types'
 
 function getIconProps(options: BadgeOptions) {
   if (canShowIcon(options.size)) {
@@ -20,9 +20,10 @@ function getIconProps(options: BadgeOptions) {
 
 export function getDefaultBadgeOptions(options?: BadgeOptions) {
   return {
+    className: options?.className ?? '',
     sentiment: options?.sentiment ?? 'default',
-    usage: options?.usage ?? 'filled',
     size: options?.size ?? 's',
+    usage: options?.usage ?? 'filled',
   }
 }
 
@@ -33,7 +34,7 @@ interface BadgeStyleKeys<SM> {
 }
 
 export function createBadgeClasses<StyleModule>(
-  options: DefaultBadgeOptions
+  options: Required<BadgeOptions>
 ): BadgeStyleKeys<StyleModule> {
   const BADGE = 'Badge'
   return {

--- a/packages/headless-styles/src/components/Badge/types.ts
+++ b/packages/headless-styles/src/components/Badge/types.ts
@@ -1,15 +1,10 @@
 import type { Sentiment, Size, Usage } from '../types'
 
 export interface BadgeOptions {
+  className?: string
   sentiment?: BadgeSentiment
-  usage?: BadgeUsage
   size?: BadgeSize
-}
-
-export interface DefaultBadgeOptions {
-  sentiment: BadgeSentiment
-  usage: BadgeUsage
-  size: BadgeSize
+  usage?: BadgeUsage
 }
 
 // types

--- a/packages/headless-styles/src/components/Button/buttonCSS.ts
+++ b/packages/headless-styles/src/components/Button/buttonCSS.ts
@@ -20,7 +20,8 @@ export function getButtonProps(options?: ButtonOptions) {
     button: {
       ...props.button,
       ...createClassNameProp(
-        `${BTN} ${styles[usageClass]} ${styles[sentimentClass]} ${styles[sizeClass]}`
+        `${BTN} ${styles[usageClass]} ${styles[sentimentClass]} ${styles[sizeClass]}`,
+        defaultOptions.className
       ),
     },
   }

--- a/packages/headless-styles/src/components/Button/shared.ts
+++ b/packages/headless-styles/src/components/Button/shared.ts
@@ -24,11 +24,12 @@ function createBtnClass(name: string) {
 
 export function getDefaultButtonOptions(options?: ButtonOptions) {
   return {
+    className: options?.className ?? '',
     disabled: options?.disabled ?? false,
     icon: options?.icon ?? '',
     sentiment: options?.sentiment ?? 'action',
-    usage: options?.usage ?? 'filled',
     size: options?.size ?? 'l',
+    usage: options?.usage ?? 'filled',
   }
 }
 

--- a/packages/headless-styles/src/components/Button/types.ts
+++ b/packages/headless-styles/src/components/Button/types.ts
@@ -6,11 +6,12 @@ export interface ButtonOptions
     ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
   > {
+  className?: string
   disabled?: boolean
-  sentiment?: ButtonSentiment
-  usage?: ButtonUsage
-  size?: ButtonSize
   icon?: ButtonIcon
+  sentiment?: ButtonSentiment
+  size?: ButtonSize
+  usage?: ButtonUsage
 }
 
 export interface DefaultButtonOptions
@@ -18,11 +19,12 @@ export interface DefaultButtonOptions
     ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
   > {
+  className: string
   disabled: boolean
-  sentiment: ButtonSentiment
-  usage: ButtonUsage
-  size: ButtonSize
   icon: ButtonIcon
+  sentiment: ButtonSentiment
+  size: ButtonSize
+  usage: ButtonUsage
 }
 
 // types

--- a/packages/headless-styles/src/components/ErrorMessage/errorMessageCSS.ts
+++ b/packages/headless-styles/src/components/ErrorMessage/errorMessageCSS.ts
@@ -16,7 +16,10 @@ export function getErrorMessageProps(options?: ErrorMessageOptions) {
     ...errorProps,
     message: {
       ...errorProps.message,
-      ...createClassNameProp(`${ERROR_MESSAGE} size-xs ${styles.errorMessage}`),
+      ...createClassNameProp(
+        `${ERROR_MESSAGE} size-xs ${styles.errorMessage}`,
+        defaultOptions.className
+      ),
     },
   }
 }

--- a/packages/headless-styles/src/components/ErrorMessage/shared.ts
+++ b/packages/headless-styles/src/components/ErrorMessage/shared.ts
@@ -10,6 +10,7 @@ function getErrorMessageA11yProps() {
 
 export function getDefaultErrorMessageOptions(options?: ErrorMessageOptions) {
   return {
+    className: options?.className ?? '',
     id: options?.id ?? '',
     invalid: options?.invalid ?? false,
     message: options?.message ?? '',

--- a/packages/headless-styles/src/components/ErrorMessage/types.ts
+++ b/packages/headless-styles/src/components/ErrorMessage/types.ts
@@ -1,4 +1,5 @@
 export interface ErrorMessageOptions {
+  className?: string
   id: string
   invalid: boolean
   message: string

--- a/packages/headless-styles/src/components/FieldMessage/fieldMessageCSS.ts
+++ b/packages/headless-styles/src/components/FieldMessage/fieldMessageCSS.ts
@@ -14,6 +14,9 @@ export function getFieldMessageProps(options?: FieldMessageOptions) {
 
   return {
     ...props,
-    ...createClassNameProp(`${FIELD_MESSAGE} size-xs ${styles.fieldMessage}`),
+    ...createClassNameProp(
+      `${FIELD_MESSAGE} size-xs ${styles.fieldMessage}`,
+      defaultOptions.className
+    ),
   }
 }

--- a/packages/headless-styles/src/components/FieldMessage/shared.ts
+++ b/packages/headless-styles/src/components/FieldMessage/shared.ts
@@ -2,6 +2,7 @@ import type { FieldMessageOptions } from './types'
 
 export function getDefaultFieldMessageOptions(options?: FieldMessageOptions) {
   return {
+    className: options?.className ?? '',
     id: options?.id ?? '',
     message: options?.message ?? '',
   }

--- a/packages/headless-styles/src/components/FieldMessage/types.ts
+++ b/packages/headless-styles/src/components/FieldMessage/types.ts
@@ -1,4 +1,5 @@
 export interface FieldMessageOptions {
+  className?: string
   id: string
   message: string
 }

--- a/packages/headless-styles/src/components/FormControl/formControlCSS.ts
+++ b/packages/headless-styles/src/components/FormControl/formControlCSS.ts
@@ -6,7 +6,7 @@ import type { FormControlOptions } from './types'
 const FORM_CONTROL = 'ps-form-control'
 
 export function getFormControlProps(options?: FormControlOptions) {
-  const { groupType, direction, ...fieldOptions } =
+  const { groupType, direction, className, ...fieldOptions } =
     getDefaultFormControlOptions(options)
   const { directionClass } = getFormControlClasses<typeof styles>(direction)
   const role = {
@@ -18,7 +18,8 @@ export function getFormControlProps(options?: FormControlOptions) {
       ...role,
       'data-disabled': fieldOptions.disabled,
       ...createClassNameProp(
-        `${FORM_CONTROL} ${styles.formControlBase} ${styles[directionClass]}`
+        `${FORM_CONTROL} ${styles.formControlBase} ${styles[directionClass]}`,
+        className
       ),
     },
     fieldOptions,

--- a/packages/headless-styles/src/components/FormControl/shared.ts
+++ b/packages/headless-styles/src/components/FormControl/shared.ts
@@ -15,6 +15,7 @@ export function getFormControlClasses<StyleModule>(
 
 export function getDefaultFormControlOptions(options?: FormControlOptions) {
   return {
+    className: options?.className ?? '',
     direction: options?.direction ?? 'row',
     disabled: options?.disabled ?? false,
     groupType: options?.groupType ?? 'group',

--- a/packages/headless-styles/src/components/FormControl/types.ts
+++ b/packages/headless-styles/src/components/FormControl/types.ts
@@ -1,6 +1,7 @@
 import type { CheckboxDirection, FieldStates } from '../types'
 
 export interface FormControlOptions extends FieldStates {
+  className?: string
   groupType?: FormControlGroupType
   direction?: CheckboxDirection
 }

--- a/packages/headless-styles/src/components/FormLabel/formLabelCSS.ts
+++ b/packages/headless-styles/src/components/FormLabel/formLabelCSS.ts
@@ -18,6 +18,9 @@ export function getFormLabelProps(options?: FormLabelOptions) {
   return {
     htmlFor,
     ...label,
-    ...createClassNameProp(`${FORM_LABEL} ${styles[labelClass]}`),
+    ...createClassNameProp(
+      `${FORM_LABEL} ${styles[labelClass]}`,
+      defaultOptions.className
+    ),
   }
 }

--- a/packages/headless-styles/src/components/FormLabel/shared.ts
+++ b/packages/headless-styles/src/components/FormLabel/shared.ts
@@ -15,6 +15,7 @@ export function getFormLabelClasses<StyleModule>(
 
 export function getDefaultFormLabelOptions(options?: FormLabelOptions) {
   return {
+    className: options?.className ?? '',
     htmlFor: options?.htmlFor ?? '',
     kind: options?.kind ?? 'default',
     required: options?.required ?? false,

--- a/packages/headless-styles/src/components/FormLabel/types.ts
+++ b/packages/headless-styles/src/components/FormLabel/types.ts
@@ -1,4 +1,5 @@
 export interface FormLabelOptions {
+  className?: string
   htmlFor: string
   kind?: Kind
   required?: boolean

--- a/packages/headless-styles/src/components/Grid/gridCSS.ts
+++ b/packages/headless-styles/src/components/Grid/gridCSS.ts
@@ -16,7 +16,10 @@ export function getGridProps(options?: GridOptions) {
 
   return {
     ...props,
-    ...createClassNameProp(`${GRID} ${styles.gridContainer}`),
+    ...createClassNameProp(
+      `${GRID} ${styles.gridContainer}`,
+      defaultOptions.className
+    ),
   }
 }
 
@@ -26,6 +29,9 @@ export function getGridItemProps(options?: GridItemOptions) {
 
   return {
     ...props,
-    ...createClassNameProp(`${GRID}-item ${styles.gridItem}`),
+    ...createClassNameProp(
+      `${GRID}-item ${styles.gridItem}`,
+      defaultOptions.className
+    ),
   }
 }

--- a/packages/headless-styles/src/components/Grid/shared.ts
+++ b/packages/headless-styles/src/components/Grid/shared.ts
@@ -13,6 +13,7 @@ export function getDefaultGridOptions(options?: GridOptions) {
     cols: options?.cols ?? 12,
     gap: options?.gap ?? 16,
     rows: options?.rows ?? 1,
+    className: options?.className ?? '',
   }
 }
 
@@ -20,6 +21,7 @@ export function getDefaultGridItemOptions(options?: GridItemOptions) {
   return {
     colSpan: options?.colSpan ?? 12,
     rowSpan: options?.rowSpan ?? null,
+    className: options?.className,
   }
 }
 

--- a/packages/headless-styles/src/components/Grid/types.ts
+++ b/packages/headless-styles/src/components/Grid/types.ts
@@ -2,11 +2,13 @@ export interface GridOptions {
   cols?: number
   gap?: GridGap
   rows?: number
+  className?: string
 }
 
 export interface GridItemOptions {
   colSpan?: number
   rowSpan?: number | null
+  className?: string
 }
 
 // types

--- a/packages/headless-styles/src/components/Icon/iconCSS.ts
+++ b/packages/headless-styles/src/components/Icon/iconCSS.ts
@@ -20,7 +20,10 @@ export function getIconProps(options?: IconOptions) {
 
   return {
     ...a11yProps,
-    ...createClassNameProp(`${ICON} ${styles[sizeClass]}`),
+    ...createClassNameProp(
+      `${ICON} ${styles[sizeClass]}`,
+      defaultOptions.className
+    ),
     ...(options?.customSize && {
       height: options.customSize,
       width: options.customSize,

--- a/packages/headless-styles/src/components/Icon/shared.ts
+++ b/packages/headless-styles/src/components/Icon/shared.ts
@@ -5,6 +5,7 @@ export function getDefaultIconOptions(options?: IconOptions) {
   return {
     ariaHidden: options?.ariaHidden ?? false,
     ariaLabel: options?.ariaLabel ?? 'icon',
+    className: options?.className ?? '',
     customSize: options?.customSize,
     size: options?.size ?? 'm',
   }

--- a/packages/headless-styles/src/components/Icon/types.ts
+++ b/packages/headless-styles/src/components/Icon/types.ts
@@ -6,6 +6,7 @@ export interface IconA11yOptions {
 }
 
 export interface IconOptions extends IconA11yOptions {
+  className?: string
   customSize?: string
   size?: IconSize
 }

--- a/packages/headless-styles/src/components/IconButton/iconButtonCSS.ts
+++ b/packages/headless-styles/src/components/IconButton/iconButtonCSS.ts
@@ -21,7 +21,8 @@ export function getIconButtonProps(options?: IconButtonOptions) {
     button: {
       ...props.button,
       ...createClassNameProp(
-        `${ICON_BTN} ${btnStyles.btnBase} ${styles[usageClass]} ${styles[sentimentClass]} ${styles[sizeClass]}`
+        `${ICON_BTN} ${btnStyles.btnBase} ${styles[usageClass]} ${styles[sentimentClass]} ${styles[sizeClass]}`,
+        defaultOptions.className
       ),
     },
   }

--- a/packages/headless-styles/src/components/IconButton/shared.ts
+++ b/packages/headless-styles/src/components/IconButton/shared.ts
@@ -25,6 +25,7 @@ function createIconBtnClass(name: string) {
 export function getDefaultIconButtonOptions(options?: IconButtonOptions) {
   return {
     ariaLabel: options?.ariaLabel ?? 'button with icon',
+    className: options?.className ?? '',
     disabled: options?.disabled ?? false,
     sentiment: options?.sentiment ?? 'action',
     usage: options?.usage ?? 'square',

--- a/packages/headless-styles/src/components/IconButton/types.ts
+++ b/packages/headless-styles/src/components/IconButton/types.ts
@@ -7,6 +7,7 @@ export interface IconButtonOptions
     HTMLButtonElement
   > {
   ariaLabel: string
+  className?: string
   disabled?: boolean
   sentiment?: ButtonSentiment
   usage?: IconButtonUsage
@@ -19,6 +20,7 @@ export interface DefaultIconButtonOptions
     HTMLButtonElement
   > {
   ariaLabel: string
+  className: string
   disabled: boolean
   sentiment: ButtonSentiment
   usage: IconButtonUsage

--- a/packages/headless-styles/src/components/Skeleton/shared.ts
+++ b/packages/headless-styles/src/components/Skeleton/shared.ts
@@ -2,6 +2,7 @@ import type { SkeletonOptions } from './types'
 
 export function getDefaultSkeletonOptions(options?: SkeletonOptions) {
   return {
+    className: options?.className ?? '',
     kind: options?.kind ?? 'content',
   }
 }

--- a/packages/headless-styles/src/components/Skeleton/skeletonCSS.ts
+++ b/packages/headless-styles/src/components/Skeleton/skeletonCSS.ts
@@ -4,8 +4,12 @@ import styles from './skeletonCSS.module.css'
 import type { SkeletonOptions } from './types'
 
 export function getSkeletonProps(options?: SkeletonOptions) {
-  const { kind } = getDefaultSkeletonOptions(options)
+  const defaultOptions = getDefaultSkeletonOptions(options)
+
   return {
-    ...createClassNameProp(`ps-skeleton ${styles[kind]}`),
+    ...createClassNameProp(
+      `ps-skeleton ${styles[defaultOptions.kind]}`,
+      defaultOptions?.className
+    ),
   }
 }

--- a/packages/headless-styles/src/components/Skeleton/types.ts
+++ b/packages/headless-styles/src/components/Skeleton/types.ts
@@ -1,4 +1,5 @@
 export interface SkeletonOptions {
+  className?: string
   kind?: SkeletonKind
 }
 

--- a/packages/headless-styles/src/components/Tag/shared.ts
+++ b/packages/headless-styles/src/components/Tag/shared.ts
@@ -3,6 +3,7 @@ import type { TagOptions, TagSize } from './types'
 
 export function getDefaultTagOptions(options?: TagOptions) {
   return {
+    className: options?.className ?? '',
     size: options?.size ?? 'm',
   }
 }

--- a/packages/headless-styles/src/components/Tag/tagCSS.ts
+++ b/packages/headless-styles/src/components/Tag/tagCSS.ts
@@ -19,7 +19,10 @@ export function getTagProps(options?: TagOptions) {
   return {
     ...props,
     tag: {
-      ...createClassNameProp(`${TAG} ${styles[sizeClass]}`),
+      ...createClassNameProp(
+        `${TAG} ${styles[sizeClass]}`,
+        defaultOptions.className
+      ),
     },
   }
 }

--- a/packages/headless-styles/src/components/Tag/types.ts
+++ b/packages/headless-styles/src/components/Tag/types.ts
@@ -1,6 +1,7 @@
 import type { Size } from '../types'
 
 export interface TagOptions {
+  className?: string
   size?: TagSize
 }
 

--- a/packages/headless-styles/src/components/TextLink/shared.ts
+++ b/packages/headless-styles/src/components/TextLink/shared.ts
@@ -27,6 +27,7 @@ function getIconOptions() {
 
 export function getDefaultTextLinkOptions(options?: TextLinkOptions) {
   return {
+    className: options?.className ?? '',
     href: options?.href ?? '',
   }
 }

--- a/packages/headless-styles/src/components/TextLink/textLinkCSS.ts
+++ b/packages/headless-styles/src/components/TextLink/textLinkCSS.ts
@@ -11,7 +11,10 @@ export function getTextLinkProps(options?: TextLinkOptions) {
     ...props,
     link: {
       ...props.link,
-      ...createClassNameProp(`ps-text-link ${styles.textLinkBase}`),
+      ...createClassNameProp(
+        `ps-text-link ${styles.textLinkBase}`,
+        defaultOptions.className
+      ),
     },
   }
 }

--- a/packages/headless-styles/src/components/TextLink/types.ts
+++ b/packages/headless-styles/src/components/TextLink/types.ts
@@ -1,3 +1,4 @@
 export interface TextLinkOptions {
+  className?: string
   href: string
 }

--- a/packages/headless-styles/src/components/Textarea/shared.ts
+++ b/packages/headless-styles/src/components/Textarea/shared.ts
@@ -3,6 +3,7 @@ import type { TextareaOptions } from './types'
 
 export function getDefaultTextareaOptions(options?: TextareaOptions) {
   return {
+    className: options?.className ?? '',
     disabled: options?.disabled ?? false,
     describedBy: options?.describedBy ?? '',
     id: options?.id ?? '',

--- a/packages/headless-styles/src/components/Textarea/types.ts
+++ b/packages/headless-styles/src/components/Textarea/types.ts
@@ -1,6 +1,7 @@
 import type { InputFieldOptions } from '../types'
 
 export interface TextareaOptions extends InputFieldOptions {
+  className?: string
   resize?: Resize
 }
 

--- a/packages/headless-styles/src/utils/helpers.ts
+++ b/packages/headless-styles/src/utils/helpers.ts
@@ -49,8 +49,8 @@ export function createA11yProps(options: FieldStates) {
   }
 }
 
-export function createClassNameProp(className: string) {
-  return { className }
+export function createClassNameProp(className: string, userClassName?: string) {
+  return { className: [className, userClassName].filter(Boolean).join(' ') }
 }
 
 export function createJSProps(styles: GeneratedStyles) {

--- a/packages/headless-styles/tests/utils/helpers.test.ts
+++ b/packages/headless-styles/tests/utils/helpers.test.ts
@@ -33,6 +33,12 @@ describe('helpers', () => {
     })
   })
 
+  test('should allow a user-provided className', () => {
+    expect(createClassNameProp('test anotherTest', 'userClass')).toMatchObject({
+      className: 'test anotherTest userClass',
+    })
+  })
+
   test('should return a JS props Object', () => {
     const styles = {
       backgroundColor: 'blue',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
contributes to #868 

## What is the new behavior?
Adds a parameter to the className prop helper for a user-provided class and, if present, merges it with the existing list.
Applied this to single-element components.  

## Other information
Multi-element components will need a more complicated approach and some discussion over how we want to handle it (I have a few ideas).
Considering a refactor of `createClassNameProp` to accept an array instead
