### PR TITLE
build(headless-styles): make headless-styles tree-shakeable

### DIFF
--- a/packages/headless-styles/npm/browser.js
+++ b/packages/headless-styles/npm/browser.js
@@ -1,7 +1,0 @@
-'use strict'
-
-if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./browser/index.production.min.js')
-} else {
-  module.exports = require('./browser/index.development.js')
-}

--- a/packages/headless-styles/npm/index.js
+++ b/packages/headless-styles/npm/index.js
@@ -1,7 +1,0 @@
-'use strict'
-
-if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./node/index.production.min.js')
-} else {
-  module.exports = require('./node/index.development.js')
-}

--- a/packages/headless-styles/package.json
+++ b/packages/headless-styles/package.json
@@ -7,8 +7,8 @@
   "types": "npm/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./npm/browser.js",
-      "require": "./npm/index.js"
+      "import": "./npm/browser/index.js",
+      "require": "./npm/node/index.js"
     },
     "./types": {
       "types": "./npm/types/types.d.ts"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

All headless-styles components end up in one file (well, technically 4 - dev and prod builds for both ESM and CJS), which renders them un-tree-shakeable.

## What is the new behavior?

Generate separate files for each component, so that common tree-shaking algorithms can remove unused component CSS.

This also removes the 'development' build, as the only real difference between prod and dev is minification, which is more properly handled by the consuming application. It also means we no longer need bundler-specific tricks to make 'process.env' work properly.

## Other information

Fixes #940 . See that issue for more details.