### PR TITLE
feat(headless-styles): update border color for inputs

### DIFF
--- a/packages/headless-styles/src/components/Checkbox/checkboxCSS.module.css
+++ b/packages/headless-styles/src/components/Checkbox/checkboxCSS.module.css
@@ -21,7 +21,7 @@
 
 .checkboxControl {
   align-items: center;
-  border-color: var(--ps-border-strong);
+  border-color: var(--ps-action-border);
   border-image: initial;
   border-radius: 2px;
   border-style: solid;

--- a/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
+++ b/packages/headless-styles/src/components/Checkbox/generated/checkboxCSS.module.ts
@@ -39,7 +39,7 @@ export default {
   },
   checkboxControl: {
     alignItems: 'center',
-    borderColor: 'var(--ps-border-strong)',
+    borderColor: 'var(--ps-action-border)',
     borderImage: 'initial',
     borderRadius: '2px',
     borderStyle: 'solid',

--- a/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
+++ b/packages/headless-styles/src/components/Input/generated/InputCSS.module.ts
@@ -12,7 +12,7 @@ export default {
   defaultInput: {
     appearance: 'none',
     background: 'var(--ps-surface-weak)',
-    borderColor: 'var(--ps-border)',
+    borderColor: 'var(--ps-action-border)',
     borderImage: 'initial',
     borderRadius: '6px',
     borderStyle: 'solid',

--- a/packages/headless-styles/src/components/Input/inputCSS.module.css
+++ b/packages/headless-styles/src/components/Input/inputCSS.module.css
@@ -7,7 +7,7 @@
 .defaultInput {
   appearance: none;
   background: var(--ps-surface-weak);
-  border-color: var(--ps-border);
+  border-color: var(--ps-action-border);
   border-image: initial;
   border-radius: 6px;
   border-style: solid;

--- a/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
+++ b/packages/headless-styles/src/components/Radio/generated/radioCSS.module.ts
@@ -42,7 +42,7 @@ export default {
   },
   radioControl: {
     alignItems: 'center',
-    borderColor: 'var(--ps-border-strong)',
+    borderColor: 'var(--ps-action-border)',
     borderImage: 'initial',
     borderRadius: '50%',
     borderStyle: 'solid',

--- a/packages/headless-styles/src/components/Radio/radioCSS.module.css
+++ b/packages/headless-styles/src/components/Radio/radioCSS.module.css
@@ -25,7 +25,7 @@
 
 .radioControl {
   align-items: center;
-  border-color: var(--ps-border-strong);
+  border-color: var(--ps-action-border);
   border-image: initial;
   border-radius: 50%;
   border-style: solid;

--- a/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
+++ b/packages/headless-styles/src/components/Select/generated/selectCSS.module.ts
@@ -11,7 +11,7 @@ export default {
     composes: "inputWrapper from '../Input/inputCSS.module.css'",
   },
   selectBase: {
-    composes: "inputBase from '../Input/inputCSS.module.css'",
+    composes: "defaultInput from '../Input/inputCSS.module.css'",
     paddingInlineEnd: '2.25rem',
     paddingInlineStart: '1rem',
   },

--- a/packages/headless-styles/src/components/Select/selectCSS.module.css
+++ b/packages/headless-styles/src/components/Select/selectCSS.module.css
@@ -7,7 +7,7 @@
 }
 
 .selectBase {
-  composes: inputBase from '../Input/inputCSS.module.css';
+  composes: defaultInput from '../Input/inputCSS.module.css';
   padding-inline-end: 2.25rem;
   padding-inline-start: 1rem;
 }

--- a/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
+++ b/packages/headless-styles/src/components/Textarea/generated/textareaCSS.module.ts
@@ -7,7 +7,7 @@ export default {
   textareaBase: {
     appearance: 'none',
     background: 'var(--ps-surface-weak)',
-    borderColor: 'var(--ps-border)',
+    borderColor: 'var(--ps-action-border)',
     borderImage: 'initial',
     borderRadius: '6px',
     borderStyle: 'solid',

--- a/packages/headless-styles/src/components/Textarea/textareaCSS.module.css
+++ b/packages/headless-styles/src/components/Textarea/textareaCSS.module.css
@@ -1,7 +1,7 @@
 .textareaBase {
   appearance: none;
   background: var(--ps-surface-weak);
-  border-color: var(--ps-border);
+  border-color: var(--ps-action-border);
   border-image: initial;
   border-radius: 6px;
   border-style: solid;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
closes #866 

## What is the new behavior?

Updates border color of input elements

<img width="728" alt="Screen Shot 2023-01-04 at 10 36 30 AM" src="https://user-images.githubusercontent.com/1745718/210594881-8888cf7c-09d9-4d82-98bf-e5676aeac660.png">
<img width="707" alt="Screen Shot 2023-01-04 at 10 36 23 AM" src="https://user-images.githubusercontent.com/1745718/210594883-e83e364a-b01b-463d-bd7d-a401bdee96b6.png">
<img width="650" alt="Screen Shot 2023-01-04 at 10 36 05 AM" src="https://user-images.githubusercontent.com/1745718/210594884-c86fefeb-3bbf-4ee5-82a4-fe9cbbfc08b9.png">
<img width="625" alt="Screen Shot 2023-01-04 at 10 35 53 AM" src="https://user-images.githubusercontent.com/1745718/210594887-64f06354-b5da-495d-acb1-d3f6b5261085.png">
<img width="740" alt="Screen Shot 2023-01-04 at 10 35 34 AM" src="https://user-images.githubusercontent.com/1745718/210594890-fa599459-8ae5-48d0-898b-a8ed7316fd59.png">
<img width="715" alt="Screen Shot 2023-01-04 at 10 35 26 AM" src="https://user-images.githubusercontent.com/1745718/210594891-52736fd3-8d2f-4eef-b207-28a773ac1595.png">
<img width="630" alt="Screen Shot 2023-01-04 at 10 35 02 AM" src="https://user-images.githubusercontent.com/1745718/210594894-b46e7dea-4484-499c-9dea-016b5cbb5532.png">
<img width="660" alt="Screen Shot 2023-01-04 at 10 34 56 AM" src="https://user-images.githubusercontent.com/1745718/210594900-131ad0d6-b644-4efd-8d1b-d7b5f82d5bc3.png">
<img width="703" alt="Screen Shot 2023-01-04 at 10 36 53 AM" src="https://user-images.githubusercontent.com/1745718/210594897-8ed00324-7747-4cf6-8aac-9923b0adaea9.png">
<img width="694" alt="Screen Shot 2023-01-04 at 10 36 45 AM" src="https://user-images.githubusercontent.com/1745718/210594901-513e2bc2-b6be-4c8c-a997-9fc9bb4f5cfa.png">


## Other information
